### PR TITLE
chore: porządkuje skille i macierz QA

### DIFF
--- a/.agents/qa-run.matrix.json
+++ b/.agents/qa-run.matrix.json
@@ -8,19 +8,15 @@
         "parser": "generic-tail"
     },
     "patternSets": {
-        "qa-run-node-tests": [
-            "eslint.config.mjs",
-            "package.json",
-            "package-lock.json",
-            ".agents/skills/qa-run/scripts/**/*.mjs",
-            "tests/skills/qa-run/**/*.mjs"
+        "project-js-ts-checks": [
+            "@js-ts-safe"
         ]
     },
     "sectionOrder": [
         "ALWAYS_FULL",
         "ALWAYS_ON_RERUN",
         "SHELL_SCRIPTS_CHANGED",
-        "NODE_TESTS_CHANGED",
+        "JS_TS_CHANGED",
         "MARKDOWN_CHANGED",
         "QA_CONFIG_CHANGED"
     ],
@@ -54,15 +50,18 @@
             ],
             "requiresFinalFullPass": false
         },
-        "NODE_TESTS_CHANGED": {
+        "JS_TS_CHANGED": {
             "patterns": [
-                "@qa-run-node-tests"
+                "@project-js-ts-checks"
             ],
             "cache": {
                 "enabled": true
             },
             "commands": [
-                "npm run lint:js",
+                {
+                    "cmd": "npm --silent run lint:js -- --format json",
+                    "parser": "eslint-json"
+                },
                 "npm test"
             ],
             "runOn": [

--- a/.agents/skills/code-implement/SKILL.md
+++ b/.agents/skills/code-implement/SKILL.md
@@ -72,6 +72,26 @@ Mechanizmy:
 - pełne QA: `$qa-run` (`<skills_root>/qa-run/SKILL.md`)
 - commit: wyłącznie `$git-commit` (`<skills_root>/git-commit/SKILL.md`)
 
+## Delegacja do skilli specjalistycznych
+Podczas implementacji nie wykonuj ręcznie operacji, które są już opisane przez
+wyspecjalizowany skill, jeśli ten skill może wykonać je precyzyjniej, szybciej
+albo z mniejszym ryzykiem pomyłki.
+
+Dla kodu PHP przed ręczną zmianą strukturalną sprawdź, czy zadanie podpada pod
+`$php-structure-refactor`. Użyj go w szczególności dla operacji na symbolach PHP,
+namespace/importach, definicjach, referencjach klas lub memberów, tworzeniu,
+kopiowaniu, przenoszeniu albo transformacji klas, rename oraz powtarzalnych
+transformacjach AST przez Rectora.
+
+Jeśli operacja pasuje do mapy operacji `$php-structure-refactor`, ten skill jest
+źródłem prawdy dla wyboru narzędzia i sposobu wykonania. Wróć do zwykłej
+implementacji dopiero wtedy, gdy `$php-structure-refactor` sam wskazuje, że
+prosty patch jest tańszy albo narzędzie nie potrafi rozstrzygnąć symbolu.
+
+Bramka praktyczna: użyj `$php-structure-refactor`, gdy operacja jest strukturalna
+albo symboliczna; zostań przy zwykłym patchu, gdy zmiana jest lokalna,
+jednoznaczna i prostsza ręcznie.
+
 ## Kiedy użyć
 Użyj, gdy użytkownik prosi o zmianę w kodzie (feature/bugfix/refactor), np.:
 - “dodaj funkcjonalność…”

--- a/.agents/skills/php-structure-refactor/SKILL.md
+++ b/.agents/skills/php-structure-refactor/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: php-structure-refactor
 description: >-
-  Strukturalna nawigacja i refaktoryzacja kodu PHP z użyciem phpactor, Rectora
-  oraz opcjonalnego formatowania php-cs-fixer po transformacji. Użyj, gdy Codex
-  ma sprawdzić definicje lub referencje symboli PHP, przenieść albo zmienić
-  nazwy klas lub memberów, wykonać powtarzalne transformacje AST, streścić dry-run
-  Rectora albo poruszać się po drzewie zależności PHP precyzyjniej niż przez
-  wyszukiwanie tekstowe.
+  Strukturalna nawigacja, analiza i refaktoryzacja kodu PHP z użyciem Phpactora,
+  Rectora oraz opcjonalnego php-cs-fixer po transformacji. Użyj przy pracy na
+  symbolach PHP, FQN, namespace/importach, typach pod offsetem, definicjach,
+  strukturze klas, referencjach klas lub memberów, tworzeniu, kopiowaniu,
+  przenoszeniu, rename albo transformacji klas/memberów, akcjach edytorowych
+  Phpactora, powtarzalnych transformacjach AST przez Rectora, albo gdy trzeba
+  poruszać się po drzewie zależności PHP precyzyjniej niż przez wyszukiwanie
+  tekstowe.
 shared_files:
   - _shared/scripts/env-load.sh
 ---
@@ -78,7 +80,8 @@ Nie używaj samego `rg` jako rozstrzygnięcia, gdy trzeba odróżnić symbole o 
 ### Przenoszenie lub Tworzenie Klas
 1. Sprawdź opcje przez `<skill_dir>/scripts/phpactor-cli.mjs help class:move --format=json`, `<skill_dir>/scripts/phpactor-cli.mjs help class:new --format=json` albo `<skill_dir>/scripts/phpactor-cli.mjs help class:copy --format=json`.
 2. Dla przeniesienia użyj `<skill_dir>/scripts/phpactor-cli.mjs class:move <src> <dest> --type=auto|class|file`.
-3. Po wykonaniu obejrzyj diff dotkniętych plików i raportuj zakres zmian.
+3. Dla tworzenia lub kopiowania klasy użyj `class:new` albo `class:copy` zgodnie z lokalnym `help`.
+4. Po wykonaniu obejrzyj diff dotkniętych plików i raportuj zakres zmian.
 
 ### Transformacje Wieloplikowe
 1. Użyj Rectora, gdy zmiana ma regułę powtarzalną i nie jest prostym przeniesieniem albo referencją symbolu.

--- a/.agents/skills/php-structure-refactor/scripts/php-cs-fixer-json-summary.mjs
+++ b/.agents/skills/php-structure-refactor/scripts/php-cs-fixer-json-summary.mjs
@@ -1,107 +1,107 @@
 #!/usr/bin/env node
 
-import {spawnSync} from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {spawnSync} from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
 
-const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const skillsRoot = path.resolve(skillDir, '..');
+const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const skillsRoot = path.resolve(skillDir, "..");
 const repoRoot = findRepoRoot();
-const fixer = resolveTool('php-cs-fixer');
+const fixer = resolveTool("php-cs-fixer");
 const args = normalizeArgs(process.argv.slice(2));
-const result = spawnSync(fixer[0], ['fix', ...args], {
+const fixerResult = spawnSync(fixer[0], ["fix", ...args], {
     cwd: repoRoot,
-    encoding: 'utf8',
+    encoding: "utf8",
     maxBuffer: 50 * 1024 * 1024,
 });
 
-if (result.status !== 0 && !result.stdout.trim()) {
+if (fixerResult.status !== 0 && !fixerResult.stdout.trim()) {
     writeJson({
         ok: false,
-        tool: 'php-cs-fixer',
-        status: result.status,
-        stderr: result.stderr.trim(),
+        tool: "php-cs-fixer",
+        status: fixerResult.status,
+        stderr: fixerResult.stderr.trim(),
     });
-    process.exit(result.status ?? 1);
+    process.exit(fixerResult.status ?? 1);
 }
 
 let payload;
 try {
-    payload = JSON.parse(extractJson(result.stdout));
+    payload = JSON.parse(extractJson(fixerResult.stdout));
 } catch (error) {
     writeJson({
         ok: false,
-        tool: 'php-cs-fixer',
-        status: result.status,
+        tool: "php-cs-fixer",
+        status: fixerResult.status,
         error: `Unable to parse php-cs-fixer JSON: ${error.message}`,
-        stdoutPreview: result.stdout.slice(0, 1200),
-        stderr: debugStderr(result.stderr),
+        stdoutPreview: fixerResult.stdout.slice(0, 1200),
+        stderr: debugStderr(fixerResult.stderr),
     });
-    process.exit(result.status === 0 ? 0 : (result.status ?? 1));
+    process.exit(fixerResult.status === 0 ? 0 : (fixerResult.status ?? 1));
 }
 
 const files = Array.isArray(payload.files) ? payload.files.map(summarizeFile) : [];
 
 writeJson({
     ok: true,
-    fixerStatus: result.status,
+    fixerStatus: fixerResult.status,
     hasChanges: files.length > 0,
     changedFiles: files.length,
     files,
     time: payload.time,
     memory: payload.memory,
-    stderr: debugStderr(result.stderr),
+    stderr: debugStderr(fixerResult.stderr),
 });
 
 function normalizeArgs(rawArgs) {
     const normalized = [...rawArgs];
-    if (!normalized.includes('--dry-run')) {
-        normalized.push('--dry-run');
+    if (!normalized.includes("--dry-run")) {
+        normalized.push("--dry-run");
     }
-    if (!normalized.includes('--diff')) {
-        normalized.push('--diff');
+    if (!normalized.includes("--diff")) {
+        normalized.push("--diff");
     }
-    if (!normalized.some((arg) => arg === '--format=json' || arg === '--format' || arg.startsWith('--format='))) {
-        normalized.push('--format=json');
+    if (!normalized.some((arg) => arg === "--format=json" || arg === "--format" || arg.startsWith("--format="))) {
+        normalized.push("--format=json");
     }
-    if (!normalized.some((arg) => arg === '--show-progress=none' || arg === '--show-progress' || arg.startsWith('--show-progress='))) {
-        normalized.push('--show-progress=none');
+    if (!normalized.some((arg) => arg === "--show-progress=none" || arg === "--show-progress" || arg.startsWith("--show-progress="))) {
+        normalized.push("--show-progress=none");
     }
     return normalized;
 }
 
 function summarizeFile(file) {
-    const diff = file.diff ?? '';
+    const diff = file.diff ?? "";
     return {
-        file: relativePath(file.name ?? ''),
-        diffLines: typeof diff === 'string' ? diff.split('\n').length : null,
-        diffPreview: typeof diff === 'string' ? normalizeDiff(diff).split('\n').slice(0, 40).join('\n') : undefined,
+        file: relativePath(file.name ?? ""),
+        diffLines: typeof diff === "string" ? diff.split("\n").length : null,
+        diffPreview: typeof diff === "string" ? normalizeDiff(diff).split("\n").slice(0, 40).join("\n") : void 0,
     };
 }
 
 function extractJson(stdout) {
     const trimmed = stdout.trimStart();
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
         return trimmed;
     }
 
-    const objectIndex = trimmed.indexOf('{');
-    const arrayIndex = trimmed.indexOf('[');
+    const objectIndex = trimmed.indexOf("{");
+    const arrayIndex = trimmed.indexOf("[");
     const indexes = [objectIndex, arrayIndex].filter((index) => index >= 0);
     if (indexes.length === 0) {
-        throw new Error('No JSON object or array found in stdout');
+        throw new Error("No JSON object or array found in stdout");
     }
 
     return trimmed.slice(Math.min(...indexes));
 }
 
 function resolveTool(tool) {
-    const envLoadPath = path.join(skillsRoot, '_shared/scripts/env-load.sh');
+    const envLoadPath = path.join(skillsRoot, "_shared/scripts/env-load.sh");
     const script = `source ${shellQuote(envLoadPath)}; resolve_tool_cmd ${shellQuote(tool)}`;
-    const resolved = spawnSync('bash', ['-lc', script], {
+    const resolved = spawnSync("bash", ["-lc", script], {
         cwd: repoRoot,
-        encoding: 'utf8',
+        encoding: "utf8",
     });
     if (resolved.status !== 0 || !resolved.stdout.trim()) {
         throw new Error(`Unable to resolve tool: ${tool}`);
@@ -110,20 +110,20 @@ function resolveTool(tool) {
 }
 
 function findRepoRoot() {
-    const result = spawnSync('git', ['-C', skillDir, 'rev-parse', '--show-toplevel'], {
-        encoding: 'utf8',
+    const gitResult = spawnSync("git", ["-C", skillDir, "rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
     });
-    if (result.status !== 0) {
-        throw new Error('Not inside a git repository');
+    if (gitResult.status !== 0) {
+        throw new Error("Not inside a git repository");
     }
-    return result.stdout.trim();
+    return gitResult.stdout.trim();
 }
 
 function relativePath(filePath) {
     if (!filePath) {
         return filePath;
     }
-    return path.relative(repoRoot, normalizeToolPath(filePath)) || '.';
+    return path.relative(repoRoot, normalizeToolPath(filePath)) || ".";
 }
 
 function normalizeToolPath(filePath) {
@@ -144,7 +144,7 @@ function normalizeToolPath(filePath) {
 
 function normalizeDiff(diff) {
     return diff
-        .split('\n')
+        .split("\n")
         .map((line) => {
             const match = line.match(/^([+-]{3})\s+(.+)$/);
             if (!match) {
@@ -153,7 +153,7 @@ function normalizeDiff(diff) {
 
             return `${match[1]} ${relativePath(match[2])}`;
         })
-        .join('\n');
+        .join("\n");
 }
 
 function shellQuote(value) {
@@ -165,9 +165,9 @@ function writeJson(value) {
 }
 
 function debugStderr(stderr) {
-    if (process.env.PHP_STRUCTURE_DEBUG !== '1') {
-        return undefined;
+    if (process.env.PHP_STRUCTURE_DEBUG !== "1") {
+        return void 0;
     }
 
-    return stderr.trim() || undefined;
+    return stderr.trim() || void 0;
 }

--- a/.agents/skills/php-structure-refactor/scripts/phpactor-cli.mjs
+++ b/.agents/skills/php-structure-refactor/scripts/phpactor-cli.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import {spawnSync} from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {spawnSync} from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
 
-const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const skillsRoot = path.resolve(skillDir, '..');
+const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const skillsRoot = path.resolve(skillDir, "..");
 const repoRoot = findRepoRoot();
 const rawArgs = process.argv.slice(2);
 
@@ -14,32 +14,32 @@ if (rawArgs.length === 0) {
     usage();
 }
 
-const phpactor = resolveTool('phpactor');
+const phpactor = resolveTool("phpactor");
 let toolWorkingDirForOutput = null;
-const args = normalizeArgs(rewritePathArgs(rawArgs, phpactor));
-const result = spawnSync(phpactor[0], [...phpactor.slice(1), ...args], {
+const phpactorArgs = normalizeArgs(rewritePathArgs(rawArgs, phpactor));
+const phpactorResult = spawnSync(phpactor[0], [...phpactor.slice(1), ...phpactorArgs], {
     cwd: repoRoot,
-    encoding: 'utf8',
+    encoding: "utf8",
     maxBuffer: 50 * 1024 * 1024,
 });
 
-const command = detectCommand(rawArgs);
-const parsedJson = parseJsonOutput(result.stdout);
-const ok = result.status === 0;
+const phpactorCommand = detectCommand(rawArgs);
+const parsedJson = parseJsonOutput(phpactorResult.stdout);
+const ok = phpactorResult.status === 0;
 
 writeJson({
     ok,
-    tool: 'phpactor',
-    mode: 'cli',
-    command,
-    args: args.map(normalizeArgForOutput),
-    status: result.status,
-    json: parsedJson ? summarizeJson(parsedJson) : undefined,
-    stdout: parsedJson ? undefined : summarizeText(result.stdout),
-    stderr: debugStderr(result.stderr),
+    tool: "phpactor",
+    mode: "cli",
+    command: phpactorCommand,
+    args: phpactorArgs.map(normalizeArgForOutput),
+    status: phpactorResult.status,
+    json: parsedJson ? summarizeJson(parsedJson) : void 0,
+    stdout: parsedJson ? void 0 : summarizeText(phpactorResult.stdout),
+    stderr: debugStderr(phpactorResult.stderr),
 });
 
-process.exit(ok ? 0 : (result.status ?? 1));
+process.exit(ok ? 0 : (phpactorResult.status ?? 1));
 
 function usage() {
     console.error(`Usage:
@@ -53,21 +53,21 @@ Examples:
     process.exit(2);
 }
 
-function normalizeArgs(args) {
-    const normalized = [...args];
-    if (!hasOption(normalized, 'no-interaction') && !normalized.includes('-n')) {
-        normalized.push('--no-interaction');
+function normalizeArgs(inputArgs) {
+    const normalized = [...inputArgs];
+    if (!hasOption(normalized, "no-interaction") && !normalized.includes("-n")) {
+        normalized.push("--no-interaction");
     }
-    if (!hasOption(normalized, 'no-ansi')) {
-        normalized.push('--no-ansi');
+    if (!hasOption(normalized, "no-ansi")) {
+        normalized.push("--no-ansi");
     }
     return normalized;
 }
 
-function rewritePathArgs(args, toolCommand) {
+function rewritePathArgs(inputArgs, toolCommand) {
     let toolRoot = null;
 
-    return args.map((arg) => {
+    return inputArgs.map((arg) => {
         const rewritten = rewritePathValue(arg, () => {
             toolRoot ??= findToolWorkingDir(toolCommand);
             return toolRoot;
@@ -77,12 +77,12 @@ function rewritePathArgs(args, toolCommand) {
 }
 
 function rewritePathValue(value, toolRootResolver) {
-    if (!value || value.startsWith('-') && !value.includes('=')) {
+    if (!value || value.startsWith("-") && !value.includes("=")) {
         return value;
     }
 
-    const equalsIndex = value.indexOf('=');
-    if (value.startsWith('--') && equalsIndex > 0) {
+    const equalsIndex = value.indexOf("=");
+    if (value.startsWith("--") && equalsIndex > 0) {
         const option = value.slice(0, equalsIndex + 1);
         const optionValue = value.slice(equalsIndex + 1);
         return `${option}${rewritePathValue(optionValue, toolRootResolver)}`;
@@ -97,19 +97,19 @@ function rewritePathValue(value, toolRootResolver) {
 }
 
 function repoRelativePathCandidate(value) {
-    if (value.startsWith('{') || value.startsWith('[')) {
+    if (value.startsWith("{") || value.startsWith("[")) {
         return null;
     }
 
     if (path.isAbsolute(value)) {
         const relative = path.relative(repoRoot, value);
-        if (!relative.startsWith('..') && relative !== '') {
+        if (!relative.startsWith("..") && relative !== "") {
             return relative;
         }
         return null;
     }
 
-    if (!value.includes('/') && !value.startsWith('.')) {
+    if (!value.includes("/") && !value.startsWith(".")) {
         return null;
     }
 
@@ -127,13 +127,13 @@ function findToolWorkingDir(toolCommand) {
         return process.env.PHP_STRUCTURE_TOOL_REPO_ROOT;
     }
 
-    const result = spawnSync(toolCommand[0], [...toolCommand.slice(1), 'status', '--no-interaction', '--no-ansi'], {
+    const statusResult = spawnSync(toolCommand[0], [...toolCommand.slice(1), "status", "--no-interaction", "--no-ansi"], {
         cwd: repoRoot,
-        encoding: 'utf8',
+        encoding: "utf8",
         maxBuffer: 1024 * 1024,
     });
-    const match = result.stdout.match(/^Working directory:\s*(.+)$/m);
-    if (result.status === 0 && match) {
+    const match = statusResult.stdout.match(/^Working directory:\s*(.+)$/m);
+    if (statusResult.status === 0 && match) {
         toolWorkingDirForOutput = match[1].trim();
         return toolWorkingDirForOutput;
     }
@@ -141,17 +141,17 @@ function findToolWorkingDir(toolCommand) {
     return repoRoot;
 }
 
-function hasOption(args, name) {
-    return args.some((arg) => arg === `--${name}` || arg.startsWith(`--${name}=`));
+function hasOption(inputArgs, name) {
+    return inputArgs.some((arg) => arg === `--${name}` || arg.startsWith(`--${name}=`));
 }
 
-function detectCommand(args) {
-    for (let index = 0; index < args.length; index += 1) {
-        const arg = args[index];
-        if (!arg.startsWith('-')) {
+function detectCommand(inputArgs) {
+    for (let index = 0; index < inputArgs.length; index += 1) {
+        const arg = inputArgs[index];
+        if (!arg.startsWith("-")) {
             return arg;
         }
-        if (optionConsumesNextValue(arg) && !arg.includes('=')) {
+        if (optionConsumesNextValue(arg) && !arg.includes("=")) {
             index += 1;
         }
     }
@@ -160,11 +160,11 @@ function detectCommand(args) {
 
 function optionConsumesNextValue(option) {
     return [
-        '--working-dir',
-        '-d',
-        '--config-extra',
-        '--format',
-        '--output-format',
+        "--working-dir",
+        "-d",
+        "--config-extra",
+        "--format",
+        "--output-format",
     ].includes(option);
 }
 
@@ -183,12 +183,12 @@ function parseJsonOutput(stdout) {
 
 function extractJson(stdout) {
     const trimmed = stdout.trimStart();
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
         return trimmed;
     }
 
-    const objectIndex = trimmed.indexOf('{');
-    const arrayIndex = trimmed.indexOf('[');
+    const objectIndex = trimmed.indexOf("{");
+    const arrayIndex = trimmed.indexOf("[");
     const indexes = [objectIndex, arrayIndex].filter((index) => index >= 0);
     if (indexes.length === 0) {
         return null;
@@ -198,11 +198,11 @@ function extractJson(stdout) {
 }
 
 function summarizeJson(payload) {
-    if (payload && typeof payload === 'object' && Array.isArray(payload.commands)) {
+    if (payload && typeof payload === "object" && Array.isArray(payload.commands)) {
         return summarizeCommandList(payload);
     }
 
-    if (payload && typeof payload === 'object' && payload.name && payload.definition) {
+    if (payload && typeof payload === "object" && payload.name && payload.definition) {
         return summarizeCommandHelp(payload);
     }
 
@@ -210,10 +210,10 @@ function summarizeJson(payload) {
 }
 
 function summarizeCommandList(payload) {
-    const commands = payload.commands.map((command) => ({
-        name: command.name,
-        description: command.description,
-        hidden: command.hidden || undefined,
+    const commands = payload.commands.map((entry) => ({
+        name: entry.name,
+        description: entry.description,
+        hidden: entry.hidden || void 0,
     }));
 
     return {
@@ -225,14 +225,14 @@ function summarizeCommandList(payload) {
                 id: namespace.id,
                 commands: namespace.commands,
             }))
-            : undefined,
+            : void 0,
     };
 }
 
 function summarizeCommandHelp(payload) {
     const options = Object.values(payload.definition.options ?? {}).map((option) => ({
         name: option.name,
-        shortcut: option.shortcut || undefined,
+        shortcut: option.shortcut || void 0,
         acceptsValue: option.accept_value,
         requiredValue: option.is_value_required,
         multiple: option.is_multiple,
@@ -253,10 +253,10 @@ function summarizeCommandHelp(payload) {
         })),
         options,
         flags: {
-            hasDryRun: options.some((option) => option.name === '--dry-run'),
-            hasFormat: options.some((option) => option.name === '--format' || option.name === '--output-format'),
-            hasFilesystem: options.some((option) => option.name === '--filesystem'),
-            hasNoInteraction: options.some((option) => option.name === '--no-interaction'),
+            hasDryRun: options.some((option) => option.name === "--dry-run"),
+            hasFormat: options.some((option) => option.name === "--format" || option.name === "--output-format"),
+            hasFilesystem: options.some((option) => option.name === "--filesystem"),
+            hasNoInteraction: options.some((option) => option.name === "--no-interaction"),
         },
     };
 }
@@ -266,14 +266,10 @@ function compact(value) {
         return value.slice(0, 80).map(compact);
     }
 
-    if (value && typeof value === 'object') {
+    if (value && typeof value === "object") {
         const output = {};
         for (const [key, item] of Object.entries(value)) {
-            if (typeof item === 'string' && item.length > 800) {
-                output[key] = `${item.slice(0, 800)}...`;
-            } else {
-                output[key] = compact(item);
-            }
+            output[key] = compactEntry(item, 800);
         }
         return output;
     }
@@ -281,16 +277,24 @@ function compact(value) {
     return value;
 }
 
+function compactEntry(item, limit) {
+    if (typeof item === "string" && item.length > limit) {
+        return `${item.slice(0, limit)}...`;
+    }
+
+    return compact(item);
+}
+
 function summarizeText(stdout) {
     const text = normalizeToolText(stdout.trim());
     if (!text) {
-        return undefined;
+        return void 0;
     }
 
-    const lines = text.split('\n');
+    const lines = text.split("\n");
     return {
         lineCount: lines.length,
-        preview: lines.slice(0, 80).join('\n'),
+        preview: lines.slice(0, 80).join("\n"),
         omittedLines: Math.max(0, lines.length - 80),
     };
 }
@@ -311,14 +315,14 @@ function normalizeToolText(text) {
 
     let normalized = text;
     for (const root of toolRoots) {
-        normalized = normalized.split(root).join('.');
+        normalized = normalized.split(root).join(".");
     }
     return normalized;
 }
 
 function normalizeArgForOutput(arg) {
-    const equalsIndex = arg.indexOf('=');
-    if (arg.startsWith('--') && equalsIndex > 0) {
+    const equalsIndex = arg.indexOf("=");
+    if (arg.startsWith("--") && equalsIndex > 0) {
         return `${arg.slice(0, equalsIndex + 1)}${normalizeArgForOutput(arg.slice(equalsIndex + 1))}`;
     }
 
@@ -330,11 +334,11 @@ function normalizeArgForOutput(arg) {
 }
 
 function resolveTool(tool) {
-    const envLoadPath = path.join(skillsRoot, '_shared/scripts/env-load.sh');
+    const envLoadPath = path.join(skillsRoot, "_shared/scripts/env-load.sh");
     const script = `source ${shellQuote(envLoadPath)}; resolve_tool_cmd ${shellQuote(tool)}`;
-    const resolved = spawnSync('bash', ['-lc', script], {
+    const resolved = spawnSync("bash", ["-lc", script], {
         cwd: repoRoot,
-        encoding: 'utf8',
+        encoding: "utf8",
     });
     if (resolved.status !== 0 || !resolved.stdout.trim()) {
         throw new Error(`Unable to resolve tool: ${tool}`);
@@ -343,20 +347,20 @@ function resolveTool(tool) {
 }
 
 function findRepoRoot() {
-    const result = spawnSync('git', ['-C', skillDir, 'rev-parse', '--show-toplevel'], {
-        encoding: 'utf8',
+    const gitResult = spawnSync("git", ["-C", skillDir, "rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
     });
-    if (result.status !== 0) {
-        throw new Error('Not inside a git repository');
+    if (gitResult.status !== 0) {
+        throw new Error("Not inside a git repository");
     }
-    return result.stdout.trim();
+    return gitResult.stdout.trim();
 }
 
 function relativePath(filePath) {
     if (!filePath) {
         return filePath;
     }
-    return path.relative(repoRoot, normalizeToolPath(filePath)) || '.';
+    return path.relative(repoRoot, normalizeToolPath(filePath)) || ".";
 }
 
 function normalizeToolPath(filePath) {
@@ -380,14 +384,10 @@ function normalizePaths(value) {
         return value.map(normalizePaths);
     }
 
-    if (value && typeof value === 'object') {
+    if (value && typeof value === "object") {
         const output = {};
         for (const [key, item] of Object.entries(value)) {
-            if (typeof item === 'string' && isPathKey(key)) {
-                output[key] = relativePath(item);
-            } else {
-                output[key] = normalizePaths(item);
-            }
+            output[key] = normalizePathEntry(key, item);
         }
         return output;
     }
@@ -395,8 +395,16 @@ function normalizePaths(value) {
     return value;
 }
 
+function normalizePathEntry(key, item) {
+    if (typeof item === "string" && isPathKey(key)) {
+        return relativePath(item);
+    }
+
+    return normalizePaths(item);
+}
+
 function isPathKey(key) {
-    return key === 'path' || key.endsWith('_path') || key.endsWith('Path') || key === 'file';
+    return key === "path" || key.endsWith("_path") || key.endsWith("Path") || key === "file";
 }
 
 function shellQuote(value) {
@@ -408,9 +416,9 @@ function writeJson(value) {
 }
 
 function debugStderr(stderr) {
-    if (process.env.PHP_STRUCTURE_DEBUG !== '1') {
-        return undefined;
+    if (process.env.PHP_STRUCTURE_DEBUG !== "1") {
+        return void 0;
     }
 
-    return stderr.trim() || undefined;
+    return stderr.trim() || void 0;
 }

--- a/.agents/skills/php-structure-refactor/scripts/phpactor-rpc.mjs
+++ b/.agents/skills/php-structure-refactor/scripts/phpactor-rpc.mjs
@@ -1,62 +1,62 @@
 #!/usr/bin/env node
 
-import {spawnSync} from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {spawnSync} from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
 
-const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const skillsRoot = path.resolve(skillDir, '..');
+const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const skillsRoot = path.resolve(skillDir, "..");
 const repoRoot = findRepoRoot();
 const args = parseOptions(process.argv.slice(2));
-const phpactor = resolveTool('phpactor');
-const request = rewriteRequestPaths(buildRequest(args), phpactor);
-const result = spawnSync(phpactor[0], [...phpactor.slice(1), 'rpc'], {
+const phpactor = resolveTool("phpactor");
+const rpcRequest = rewriteRequestPaths(buildRequest(args), phpactor);
+const rpcResult = spawnSync(phpactor[0], [...phpactor.slice(1), "rpc"], {
     cwd: repoRoot,
-    input: JSON.stringify(request),
-    encoding: 'utf8',
+    input: JSON.stringify(rpcRequest),
+    encoding: "utf8",
     maxBuffer: 20 * 1024 * 1024,
 });
 
-if (result.status !== 0) {
+if (rpcResult.status !== 0) {
     writeJson({
         ok: false,
-        tool: 'phpactor',
-        mode: 'rpc',
-        status: result.status,
-        stderr: result.stderr.trim(),
-        stdout: result.stdout.trim(),
+        tool: "phpactor",
+        mode: "rpc",
+        status: rpcResult.status,
+        stderr: rpcResult.stderr.trim(),
+        stdout: rpcResult.stdout.trim(),
     });
-    process.exit(result.status ?? 1);
+    process.exit(rpcResult.status ?? 1);
 }
 
 let payload;
 try {
-    payload = JSON.parse(result.stdout);
+    payload = JSON.parse(rpcResult.stdout);
 } catch (error) {
     writeJson({
         ok: false,
-        tool: 'phpactor',
-        mode: 'rpc',
+        tool: "phpactor",
+        mode: "rpc",
         error: `Unable to parse phpactor JSON: ${error.message}`,
-        stdoutPreview: result.stdout.slice(0, 2000),
-        stderr: debugStderr(result.stderr),
+        stdoutPreview: rpcResult.stdout.slice(0, 2000),
+        stderr: debugStderr(rpcResult.stderr),
     });
     process.exit(1);
 }
 
-const summary = summarizeAction(payload, parsePositiveInt(args.limit, 12));
+const rpcSummary = summarizeAction(payload, parsePositiveInt(args.limit, 12));
 writeJson({
     ok: true,
-    tool: 'phpactor',
-    mode: 'rpc',
+    tool: "phpactor",
+    mode: "rpc",
     request: {
-        action: request.action,
-        parameterKeys: Object.keys(request.parameters ?? {}),
+        action: rpcRequest.action,
+        parameterKeys: Object.keys(rpcRequest.parameters ?? {}),
     },
-    effects: collectEffects(summary),
-    summary,
-    stderr: debugStderr(result.stderr),
+    effects: collectEffects(rpcSummary),
+    summary: rpcSummary,
+    stderr: debugStderr(rpcResult.stderr),
 });
 
 function usage() {
@@ -68,12 +68,12 @@ function usage() {
 }
 
 function buildRequest(opts) {
-    if (opts['request-json'] || opts['request-file']) {
-        const request = readJsonOption(opts, 'request');
-        if (!request || typeof request !== 'object' || !request.action) {
-            throw new Error('RPC request must be an object with an action field');
+    if (opts["request-json"] || opts["request-file"]) {
+        const requestValue = readJsonOption(opts, "request");
+        if (!requestValue || typeof requestValue !== "object" || !requestValue.action) {
+            throw new Error("RPC request must be an object with an action field");
         }
-        return request;
+        return requestValue;
     }
 
     const action = opts.action;
@@ -81,12 +81,12 @@ function buildRequest(opts) {
         usage();
     }
 
-    const parameters = opts['params-json'] || opts['params-file']
-        ? readJsonOption(opts, 'params')
+    const parameters = opts["params-json"] || opts["params-file"]
+        ? readJsonOption(opts, "params")
         : {};
 
-    if (!parameters || typeof parameters !== 'object' || Array.isArray(parameters)) {
-        throw new Error('RPC parameters must be a JSON object');
+    if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+        throw new Error("RPC parameters must be a JSON object");
     }
 
     return {action, parameters};
@@ -102,7 +102,7 @@ function readJsonOption(opts, prefix) {
         usage();
     }
 
-    const raw = jsonValue ?? fs.readFileSync(absolutePath(fileValue), 'utf8');
+    const raw = jsonValue ?? fs.readFileSync(absolutePath(fileValue), "utf8");
     return JSON.parse(raw);
 }
 
@@ -124,14 +124,10 @@ function rewritePathObject(value, rewritePath) {
         return value.map((item) => rewritePathObject(item, rewritePath));
     }
 
-    if (value && typeof value === 'object') {
+    if (value && typeof value === "object") {
         const output = {};
         for (const [key, item] of Object.entries(value)) {
-            if (typeof item === 'string' && isPathKey(key)) {
-                output[key] = rewritePath(item);
-            } else {
-                output[key] = rewritePathObject(item, rewritePath);
-            }
+            output[key] = rewritePathEntry(key, item, rewritePath);
         }
         return output;
     }
@@ -139,20 +135,28 @@ function rewritePathObject(value, rewritePath) {
     return value;
 }
 
+function rewritePathEntry(key, item, rewritePath) {
+    if (typeof item === "string" && isPathKey(key)) {
+        return rewritePath(item);
+    }
+
+    return rewritePathObject(item, rewritePath);
+}
+
 function repoRelativePathCandidate(value) {
-    if (!value || value.startsWith('{') || value.startsWith('[')) {
+    if (!value || value.startsWith("{") || value.startsWith("[")) {
         return null;
     }
 
     if (path.isAbsolute(value)) {
         const relative = path.relative(repoRoot, value);
-        if (!relative.startsWith('..') && relative !== '') {
+        if (!relative.startsWith("..") && relative !== "") {
             return relative;
         }
         return null;
     }
 
-    if (!value.includes('/') && !value.startsWith('.')) {
+    if (!value.includes("/") && !value.startsWith(".")) {
         return null;
     }
 
@@ -170,13 +174,13 @@ function findToolWorkingDir(toolCommand) {
         return process.env.PHP_STRUCTURE_TOOL_REPO_ROOT;
     }
 
-    const result = spawnSync(toolCommand[0], [...toolCommand.slice(1), 'status', '--no-interaction', '--no-ansi'], {
+    const statusResult = spawnSync(toolCommand[0], [...toolCommand.slice(1), "status", "--no-interaction", "--no-ansi"], {
         cwd: repoRoot,
-        encoding: 'utf8',
+        encoding: "utf8",
         maxBuffer: 1024 * 1024,
     });
-    const match = result.stdout.match(/^Working directory:\s*(.+)$/m);
-    if (result.status === 0 && match) {
+    const match = statusResult.stdout.match(/^Working directory:\s*(.+)$/m);
+    if (statusResult.status === 0 && match) {
         return match[1].trim();
     }
 
@@ -187,7 +191,12 @@ function summarizeAction(action, limit) {
     const actionName = action.action ?? action.name;
     const parameters = action.parameters ?? {};
 
-    if (actionName === 'collection') {
+    const simpleSummary = summarizeSimpleAction(actionName, parameters);
+    if (simpleSummary) {
+        return simpleSummary;
+    }
+
+    if (actionName === "collection") {
         const actions = parameters.actions ?? [];
         return {
             action: actionName,
@@ -197,7 +206,7 @@ function summarizeAction(action, limit) {
         };
     }
 
-    if (actionName === 'file_references') {
+    if (actionName === "file_references") {
         const references = parameters.references ?? parameters.file_references ?? [];
         const limitedReferences = references.slice(0, limit);
         const totalReferences = references.reduce((sum, entry) => sum + (entry.references ?? []).length, 0);
@@ -208,7 +217,7 @@ function summarizeAction(action, limit) {
             shownFiles: limitedReferences.length,
             omittedFiles: Math.max(0, references.length - limitedReferences.length),
             files: limitedReferences.map((entry) => ({
-                file: relativePath(entry.file ?? entry.path ?? ''),
+                file: relativePath(entry.file ?? entry.path ?? ""),
                 count: (entry.references ?? []).length,
                 firstReferences: (entry.references ?? []).slice(0, 5).map((ref) => ({
                     line: ref.line_no ?? ref.line ?? null,
@@ -218,39 +227,7 @@ function summarizeAction(action, limit) {
         };
     }
 
-    if (actionName === 'open_file') {
-        return {
-            action: actionName,
-            file: relativePath(parameters.path ?? ''),
-            offset: parameters.offset ?? null,
-        };
-    }
-
-    if (actionName === 'replace_file_source') {
-        return {
-            action: actionName,
-            path: relativePath(parameters.path ?? ''),
-            sourceLength: typeof parameters.source === 'string' ? parameters.source.length : null,
-        };
-    }
-
-    if (actionName === 'input_callback') {
-        return {
-            action: actionName,
-            callback: parameters.callback ?? parameters.name ?? null,
-            label: parameters.label ?? parameters.title ?? null,
-            parameters: compact(normalizePaths(parameters)),
-        };
-    }
-
-    if (actionName === 'return') {
-        return {
-            action: actionName,
-            value: compact(normalizePaths(parameters.value)),
-        };
-    }
-
-    if (actionName === 'information') {
+    if (actionName === "information") {
         const information = parseJsonString(parameters.information);
         if (information !== null) {
             return {
@@ -261,21 +238,7 @@ function summarizeAction(action, limit) {
 
         return {
             action: actionName,
-            preview: String(parameters.information ?? '').slice(0, 1200),
-        };
-    }
-
-    if (actionName === 'echo') {
-        return {
-            action: actionName,
-            preview: String(parameters.message ?? '').slice(0, 1200),
-        };
-    }
-
-    if (actionName === 'error') {
-        return {
-            action: actionName,
-            message: String(parameters.message ?? '').slice(0, 1200),
+            preview: String(parameters.information ?? "").slice(0, 1200),
         };
     }
 
@@ -285,17 +248,46 @@ function summarizeAction(action, limit) {
     };
 }
 
-function collectEffects(summary) {
+function summarizeSimpleAction(actionName, parameters) {
+    const handlers = {
+        echo: () => ({action: actionName, preview: String(parameters.message ?? "").slice(0, 1200)}),
+        error: () => ({action: actionName, message: String(parameters.message ?? "").slice(0, 1200)}),
+        "input_callback": () => ({
+            action: actionName,
+            callback: parameters.callback ?? parameters.name ?? null,
+            label: parameters.label ?? parameters.title ?? null,
+            parameters: compact(normalizePaths(parameters)),
+        }),
+        "open_file": () => ({
+            action: actionName,
+            file: relativePath(parameters.path ?? ""),
+            offset: parameters.offset ?? null,
+        }),
+        "replace_file_source": () => ({
+            action: actionName,
+            path: relativePath(parameters.path ?? ""),
+            sourceLength: typeof parameters.source === "string" ? parameters.source.length : null,
+        }),
+        return: () => ({
+            action: actionName,
+            value: compact(normalizePaths(parameters.value)),
+        }),
+    };
+
+    return handlers[actionName]?.() ?? null;
+}
+
+function collectEffects(actionSummary) {
     const effects = {
         hasInputCallback: false,
         hasReplaceFileSource: false,
     };
 
-    visitSummary(summary, (item) => {
-        if (item.action === 'input_callback') {
+    visitSummary(actionSummary, (item) => {
+        if (item.action === "input_callback") {
             effects.hasInputCallback = true;
         }
-        if (item.action === 'replace_file_source') {
+        if (item.action === "replace_file_source") {
             effects.hasReplaceFileSource = true;
         }
     });
@@ -311,7 +303,7 @@ function visitSummary(value, visitor) {
         return;
     }
 
-    if (value && typeof value === 'object') {
+    if (value && typeof value === "object") {
         visitor(value);
         for (const item of Object.values(value)) {
             visitSummary(item, visitor);
@@ -324,14 +316,10 @@ function compact(value) {
         return value.slice(0, 50).map(compact);
     }
 
-    if (value && typeof value === 'object') {
+    if (value && typeof value === "object") {
         const output = {};
         for (const [key, item] of Object.entries(value)) {
-            if (typeof item === 'string' && item.length > 500) {
-                output[key] = `${item.slice(0, 500)}...`;
-            } else {
-                output[key] = compact(item);
-            }
+            output[key] = compactEntry(item, 500);
         }
         return output;
     }
@@ -339,22 +327,30 @@ function compact(value) {
     return value;
 }
 
+function compactEntry(item, limit) {
+    if (typeof item === "string" && item.length > limit) {
+        return `${item.slice(0, limit)}...`;
+    }
+
+    return compact(item);
+}
+
 function parseOptions(rawArgs) {
     const parsed = {};
     for (let index = 0; index < rawArgs.length; index += 1) {
         const rawKey = rawArgs[index];
-        if (!rawKey.startsWith('--')) {
+        if (!rawKey.startsWith("--")) {
             usage();
         }
 
-        const equalsIndex = rawKey.indexOf('=');
+        const equalsIndex = rawKey.indexOf("=");
         if (equalsIndex > 0) {
             parsed[rawKey.slice(2, equalsIndex)] = rawKey.slice(equalsIndex + 1);
             continue;
         }
 
         const value = rawArgs[index + 1];
-        if (value === undefined || value.startsWith('--')) {
+        if (value === void 0 || value.startsWith("--")) {
             usage();
         }
 
@@ -365,7 +361,7 @@ function parseOptions(rawArgs) {
 }
 
 function parsePositiveInt(value, fallback) {
-    if (value === undefined) {
+    if (value === void 0) {
         return fallback;
     }
 
@@ -378,11 +374,11 @@ function parsePositiveInt(value, fallback) {
 }
 
 function resolveTool(tool) {
-    const envLoadPath = path.join(skillsRoot, '_shared/scripts/env-load.sh');
+    const envLoadPath = path.join(skillsRoot, "_shared/scripts/env-load.sh");
     const script = `source ${shellQuote(envLoadPath)}; resolve_tool_cmd ${shellQuote(tool)}`;
-    const resolved = spawnSync('bash', ['-lc', script], {
+    const resolved = spawnSync("bash", ["-lc", script], {
         cwd: repoRoot,
-        encoding: 'utf8',
+        encoding: "utf8",
     });
     if (resolved.status !== 0 || !resolved.stdout.trim()) {
         throw new Error(`Unable to resolve tool: ${tool}`);
@@ -391,13 +387,13 @@ function resolveTool(tool) {
 }
 
 function findRepoRoot() {
-    const result = spawnSync('git', ['-C', skillDir, 'rev-parse', '--show-toplevel'], {
-        encoding: 'utf8',
+    const gitResult = spawnSync("git", ["-C", skillDir, "rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
     });
-    if (result.status !== 0) {
-        throw new Error('Not inside a git repository');
+    if (gitResult.status !== 0) {
+        throw new Error("Not inside a git repository");
     }
-    return result.stdout.trim();
+    return gitResult.stdout.trim();
 }
 
 function absolutePath(filePath) {
@@ -408,7 +404,7 @@ function relativePath(filePath) {
     if (!filePath) {
         return filePath;
     }
-    return path.relative(repoRoot, normalizeToolPath(filePath)) || '.';
+    return path.relative(repoRoot, normalizeToolPath(filePath)) || ".";
 }
 
 function normalizeToolPath(filePath) {
@@ -432,14 +428,10 @@ function normalizePaths(value) {
         return value.map(normalizePaths);
     }
 
-    if (value && typeof value === 'object') {
+    if (value && typeof value === "object") {
         const output = {};
         for (const [key, item] of Object.entries(value)) {
-            if (typeof item === 'string' && isPathKey(key)) {
-                output[key] = relativePath(item);
-            } else {
-                output[key] = normalizePaths(item);
-            }
+            output[key] = normalizePathEntry(key, item);
         }
         return output;
     }
@@ -447,17 +439,25 @@ function normalizePaths(value) {
     return value;
 }
 
+function normalizePathEntry(key, item) {
+    if (typeof item === "string" && isPathKey(key)) {
+        return relativePath(item);
+    }
+
+    return normalizePaths(item);
+}
+
 function isPathKey(key) {
-    return key === 'path' || key === 'file' || key.endsWith('_path') || key.endsWith('Path');
+    return key === "path" || key === "file" || key.endsWith("_path") || key.endsWith("Path");
 }
 
 function parseJsonString(value) {
-    if (typeof value !== 'string') {
+    if (typeof value !== "string") {
         return null;
     }
 
     const trimmed = value.trim();
-    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
         return null;
     }
 
@@ -477,9 +477,9 @@ function writeJson(value) {
 }
 
 function debugStderr(stderr) {
-    if (process.env.PHP_STRUCTURE_DEBUG !== '1') {
-        return undefined;
+    if (process.env.PHP_STRUCTURE_DEBUG !== "1") {
+        return void 0;
     }
 
-    return stderr.trim() || undefined;
+    return stderr.trim() || void 0;
 }

--- a/.agents/skills/php-structure-refactor/scripts/rector-json-summary.mjs
+++ b/.agents/skills/php-structure-refactor/scripts/rector-json-summary.mjs
@@ -1,47 +1,47 @@
 #!/usr/bin/env node
 
-import {spawnSync} from 'node:child_process';
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {spawnSync} from "node:child_process";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
 
-const NO_ACTIVE_RULES_REASON = 'Rector config has no active rules or sets.';
-const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const skillsRoot = path.resolve(skillDir, '..');
+const NO_ACTIVE_RULES_REASON = "Rector config has no active rules or sets.";
+const skillDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const skillsRoot = path.resolve(skillDir, "..");
 const repoRoot = findRepoRoot();
 const rawArgs = process.argv.slice(2);
-const rector = resolveTool('rector');
-const args = normalizeArgs(rawArgs);
-const result = spawnSync(rector[0], ['process', ...args], {
+const rector = resolveTool("rector");
+const rectorArgs = normalizeArgs(rawArgs);
+const rectorResult = spawnSync(rector[0], ["process", ...rectorArgs], {
     cwd: repoRoot,
-    encoding: 'utf8',
+    encoding: "utf8",
     maxBuffer: 50 * 1024 * 1024,
 });
 
-if (result.status !== 0 && !result.stdout.trim()) {
+if (rectorResult.status !== 0 && !rectorResult.stdout.trim()) {
     writeJson({
         ok: false,
-        tool: 'rector',
-        status: result.status,
-        stderr: result.stderr.trim(),
-        stdout: result.stdout.trim(),
+        tool: "rector",
+        status: rectorResult.status,
+        stderr: rectorResult.stderr.trim(),
+        stdout: rectorResult.stdout.trim(),
     });
-    process.exit(result.status ?? 1);
+    process.exit(rectorResult.status ?? 1);
 }
 
 let payload;
 try {
-    payload = JSON.parse(extractJson(result.stdout));
+    payload = JSON.parse(extractJson(rectorResult.stdout));
 } catch (error) {
-    const reason = summarizeNonJsonOutput(result.stdout);
+    const reason = summarizeNonJsonOutput(rectorResult.stdout);
     writeJson({
         ok: false,
-        tool: 'rector',
-        status: result.status,
+        tool: "rector",
+        status: rectorResult.status,
         reason,
-        error: reason === NO_ACTIVE_RULES_REASON ? undefined : `Unable to parse Rector JSON: ${error.message}`,
-        stderr: debugStderr(result.stderr),
+        error: reason === NO_ACTIVE_RULES_REASON ? void 0 : `Unable to parse Rector JSON: ${error.message}`,
+        stderr: debugStderr(rectorResult.stderr),
     });
-    process.exit(result.status === 0 ? 0 : (result.status ?? 1));
+    process.exit(rectorResult.status === 0 ? 0 : (rectorResult.status ?? 1));
 }
 
 const fileDiffs = payload.file_diffs ?? payload.fileDiffs ?? payload.files ?? [];
@@ -51,50 +51,50 @@ const files = Array.isArray(fileDiffs)
 
 writeJson({
     ok: true,
-    rectorStatus: result.status,
+    rectorStatus: rectorResult.status,
     hasChanges: files.length > 0,
     changedFiles: files.length,
     files,
-    totals: payload.totals ?? payload.summary ?? undefined,
-    stderr: debugStderr(result.stderr),
+    totals: payload.totals ?? payload.summary ?? void 0,
+    stderr: debugStderr(rectorResult.stderr),
 });
 
-function normalizeArgs(args) {
-    const normalized = [...args];
-    if (!normalized.includes('--dry-run') && !normalized.includes('-n')) {
-        normalized.push('--dry-run');
+function normalizeArgs(inputArgs) {
+    const normalized = [...inputArgs];
+    if (!normalized.includes("--dry-run") && !normalized.includes("-n")) {
+        normalized.push("--dry-run");
     }
-    if (!normalized.some((arg) => arg === '--output-format=json' || arg === '--output-format' || arg.startsWith('--output-format='))) {
-        normalized.push('--output-format=json');
+    if (!normalized.some((arg) => arg === "--output-format=json" || arg === "--output-format" || arg.startsWith("--output-format="))) {
+        normalized.push("--output-format=json");
     }
-    if (!normalized.includes('--no-progress-bar')) {
-        normalized.push('--no-progress-bar');
+    if (!normalized.includes("--no-progress-bar")) {
+        normalized.push("--no-progress-bar");
     }
     return normalized;
 }
 
 function summarizeFileDiff(entry) {
-    const file = entry.file ?? entry.relative_file_path ?? entry.relativeFilePath ?? entry.path ?? '';
-    const diff = entry.diff ?? entry.patch ?? '';
+    const file = entry.file ?? entry.relative_file_path ?? entry.relativeFilePath ?? entry.path ?? "";
+    const diff = entry.diff ?? entry.patch ?? "";
     return {
         file,
         appliedRectors: entry.applied_rectors ?? entry.appliedRectors ?? entry.rectors ?? [],
-        diffLines: typeof diff === 'string' ? diff.split('\n').length : null,
-        diffPreview: typeof diff === 'string' ? diff.split('\n').slice(0, 40).join('\n') : undefined,
+        diffLines: typeof diff === "string" ? diff.split("\n").length : null,
+        diffPreview: typeof diff === "string" ? diff.split("\n").slice(0, 40).join("\n") : void 0,
     };
 }
 
 function extractJson(stdout) {
     const trimmed = stdout.trimStart();
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
         return trimmed;
     }
 
-    const objectIndex = trimmed.indexOf('{');
-    const arrayIndex = trimmed.indexOf('[');
+    const objectIndex = trimmed.indexOf("{");
+    const arrayIndex = trimmed.indexOf("[");
     const indexes = [objectIndex, arrayIndex].filter((index) => index >= 0);
     if (indexes.length === 0) {
-        throw new Error('No JSON object or array found in stdout');
+        throw new Error("No JSON object or array found in stdout");
     }
 
     return trimmed.slice(Math.min(...indexes));
@@ -102,12 +102,12 @@ function extractJson(stdout) {
 
 function summarizeNonJsonOutput(stdout) {
     const normalized = stdout
-        .split('\n')
+        .split("\n")
         .map((line) => line.trim())
         .filter(Boolean)
-        .join(' ');
+        .join(" ");
 
-    if (normalized.includes('Register rules or sets')) {
+    if (normalized.includes("Register rules or sets")) {
         return NO_ACTIVE_RULES_REASON;
     }
 
@@ -115,11 +115,11 @@ function summarizeNonJsonOutput(stdout) {
 }
 
 function resolveTool(tool) {
-    const envLoadPath = path.join(skillsRoot, '_shared/scripts/env-load.sh');
+    const envLoadPath = path.join(skillsRoot, "_shared/scripts/env-load.sh");
     const script = `source ${shellQuote(envLoadPath)}; resolve_tool_cmd ${shellQuote(tool)}`;
-    const resolved = spawnSync('bash', ['-lc', script], {
+    const resolved = spawnSync("bash", ["-lc", script], {
         cwd: repoRoot,
-        encoding: 'utf8',
+        encoding: "utf8",
     });
     if (resolved.status !== 0 || !resolved.stdout.trim()) {
         throw new Error(`Unable to resolve tool: ${tool}`);
@@ -128,13 +128,13 @@ function resolveTool(tool) {
 }
 
 function findRepoRoot() {
-    const result = spawnSync('git', ['-C', skillDir, 'rev-parse', '--show-toplevel'], {
-        encoding: 'utf8',
+    const gitResult = spawnSync("git", ["-C", skillDir, "rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
     });
-    if (result.status !== 0) {
-        throw new Error('Not inside a git repository');
+    if (gitResult.status !== 0) {
+        throw new Error("Not inside a git repository");
     }
-    return result.stdout.trim();
+    return gitResult.stdout.trim();
 }
 
 function shellQuote(value) {
@@ -146,9 +146,9 @@ function writeJson(value) {
 }
 
 function debugStderr(stderr) {
-    if (process.env.PHP_STRUCTURE_DEBUG !== '1') {
-        return undefined;
+    if (process.env.PHP_STRUCTURE_DEBUG !== "1") {
+        return void 0;
     }
 
-    return stderr.trim() || undefined;
+    return stderr.trim() || void 0;
 }

--- a/.agents/skills/qa-run/scripts/run-matrix/app/run-matrix-app.mjs
+++ b/.agents/skills/qa-run/scripts/run-matrix/app/run-matrix-app.mjs
@@ -55,121 +55,36 @@ const RERUN_REASONS = new Set([
 
 export class RunMatrixApp {
     async run(argv = process.argv.slice(2)) {
-        let cli;
-        try {
-            cli = parseArgs(argv);
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            printHelp();
-            process.exit(2);
-        }
+        const cli = parseCliOrExit(argv);
 
         if (cli.help) {
             printHelp();
             process.exit(0);
         }
 
-        try {
-            enforceRerunReasonConsistency(cli);
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            process.exit(2);
-        }
+        enforceRerunReasonOrExit(cli);
 
-        let repoRoot = "";
-        try {
-            repoRoot = getRepoRoot();
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            process.exit(3);
-        }
-
-        const snapshotWriteAbsPath = cli.snapshotWritePath
-            ? resolveRepoPath(repoRoot, cli.snapshotWritePath)
-            : null;
-        const deltaFromSnapshotAbsPath = cli.deltaFromSnapshotPath
-            ? resolveRepoPath(repoRoot, cli.deltaFromSnapshotPath)
-            : null;
-
-        let currentState;
-        try {
-            currentState = collectWorkingTreeState(repoRoot);
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            process.exit(3);
-        }
-
-        if (snapshotWriteAbsPath) {
-            writeSnapshot(snapshotWriteAbsPath, currentState);
-            console.log(`INFO: Snapshot written: ${snapshotWriteAbsPath}`);
-        }
+        const repoRoot = getRepoRootOrExit();
+        const currentState = collectWorkingTreeStateOrExit(repoRoot);
+        const snapshotPaths = resolveSnapshotPaths(repoRoot, cli);
+        writeSnapshotIfRequested(snapshotPaths.snapshotWriteAbsPath, currentState);
 
         if (cli.snapshotOnly) {
             console.log("Result: snapshot created.");
             process.exit(0);
         }
 
-        let files = Object.keys(currentState.files).sort();
-        let mode = "full";
-
-        if (deltaFromSnapshotAbsPath) {
-            let snapshot;
-            try {
-                snapshot = loadSnapshot(deltaFromSnapshotAbsPath);
-            } catch (error) {
-                console.error(`ERROR: ${error.message}`);
-                process.exit(2);
-            }
-
-            try {
-                assertSnapshotRepoRoot(snapshot, repoRoot);
-            } catch (error) {
-                console.error(`ERROR: ${error.message}`);
-                process.exit(2);
-            }
-
-            files = detectChangedFilesFromSnapshot(currentState, snapshot);
-            mode = "delta";
-        }
-
-        const configAbsPath = path.isAbsolute(cli.configPath)
-            ? cli.configPath
-            : path.join(repoRoot, cli.configPath);
-
-        let wasCreated = false;
-        try {
-            wasCreated = ensureConfig(configAbsPath);
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            process.exit(2);
-        }
-        if (wasCreated) {
-            console.log(`INFO: Config file not found. Copied default config template to: ${configAbsPath}`);
-        }
-
-        let config;
-        try {
-            config = loadConfig(configAbsPath);
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            process.exit(2);
-        }
+        const {files, mode} = resolveRunScopeOrExit(repoRoot, currentState, snapshotPaths.deltaFromSnapshotAbsPath);
+        const config = loadConfigOrExit(resolveConfigPath(repoRoot, cli.configPath));
 
         const sessionAbsPath = cli.sessionPath
             ? resolveRepoPath(repoRoot, cli.sessionPath)
             : null;
-
-        let session;
-        try {
-            session = loadSession(sessionAbsPath);
-        } catch (error) {
-            console.error(`ERROR: ${error.message}`);
-            process.exit(2);
-        }
+        const session = loadSessionOrExit(sessionAbsPath);
 
         const artifacts = createArtifacts(repoRoot, cli.rerunReason);
         const activeSections = detectActiveSections(files, config, mode);
-        printDetectedChanges(mode, cli.rerunReason, files, activeSections, config, deltaFromSnapshotAbsPath, artifacts);
+        printDetectedChanges(mode, cli.rerunReason, files, activeSections, config, snapshotPaths.deltaFromSnapshotAbsPath, artifacts);
         const configNotices = collectConfigNotices(config, activeSections);
         printConfigNotices(configNotices);
 
@@ -259,6 +174,133 @@ export class RunMatrixApp {
         });
         writeRunSummary(artifacts, passSummary);
         console.log(`INFO: QA summary written: ${artifacts.summaryJson}`);
+    }
+}
+
+function parseCliOrExit(argv) {
+    try {
+        return parseArgs(argv);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        printHelp();
+        process.exit(2);
+        throw error;
+    }
+}
+
+function enforceRerunReasonOrExit(cli) {
+    try {
+        enforceRerunReasonConsistency(cli);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(2);
+        throw error;
+    }
+}
+
+function getRepoRootOrExit() {
+    try {
+        return getRepoRoot();
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(3);
+        throw error;
+    }
+}
+
+function collectWorkingTreeStateOrExit(repoRoot) {
+    try {
+        return collectWorkingTreeState(repoRoot);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(3);
+        throw error;
+    }
+}
+
+function resolveSnapshotPaths(repoRoot, cli) {
+    return {
+        deltaFromSnapshotAbsPath: cli.deltaFromSnapshotPath
+            ? resolveRepoPath(repoRoot, cli.deltaFromSnapshotPath)
+            : null,
+        snapshotWriteAbsPath: cli.snapshotWritePath
+            ? resolveRepoPath(repoRoot, cli.snapshotWritePath)
+            : null,
+    };
+}
+
+function writeSnapshotIfRequested(snapshotWriteAbsPath, currentState) {
+    if (!snapshotWriteAbsPath) {
+        return;
+    }
+
+    writeSnapshot(snapshotWriteAbsPath, currentState);
+    console.log(`INFO: Snapshot written: ${snapshotWriteAbsPath}`);
+}
+
+function resolveRunScopeOrExit(repoRoot, currentState, deltaFromSnapshotAbsPath) {
+    if (!deltaFromSnapshotAbsPath) {
+        return {
+            files: Object.keys(currentState.files).sort(),
+            mode: "full",
+        };
+    }
+
+    const snapshot = loadSnapshotOrExit(deltaFromSnapshotAbsPath);
+    assertSnapshotRepoRootOrExit(snapshot, repoRoot);
+    return {
+        files: detectChangedFilesFromSnapshot(currentState, snapshot),
+        mode: "delta",
+    };
+}
+
+function loadSnapshotOrExit(deltaFromSnapshotAbsPath) {
+    try {
+        return loadSnapshot(deltaFromSnapshotAbsPath);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(2);
+        throw error;
+    }
+}
+
+function assertSnapshotRepoRootOrExit(snapshot, repoRoot) {
+    try {
+        assertSnapshotRepoRoot(snapshot, repoRoot);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(2);
+        throw error;
+    }
+}
+
+function resolveConfigPath(repoRoot, configPath) {
+    return path.isAbsolute(configPath)
+        ? configPath
+        : path.join(repoRoot, configPath);
+}
+
+function loadConfigOrExit(configAbsPath) {
+    try {
+        const wasCreated = ensureConfig(configAbsPath);
+        if (wasCreated) {
+            console.log(`INFO: Config file not found. Copied default config template to: ${configAbsPath}`);
+        }
+        return loadConfig(configAbsPath);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(2);
+        throw error;
+    }
+}
+
+function loadSessionOrExit(sessionAbsPath) {
+    try {
+        return loadSession(sessionAbsPath);
+    } catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        process.exit(2);
+        throw error;
     }
 }
 

--- a/.agents/skills/qa-run/scripts/run-matrix/config/normalizer.mjs
+++ b/.agents/skills/qa-run/scripts/run-matrix/config/normalizer.mjs
@@ -141,7 +141,7 @@ function normalizePatternSets(value) {
 }
 
 function normalizeSectionCacheConfig(sectionName, value, resolvedPatterns) {
-    if (value === undefined) {
+    if (value === void 0) {
         return {enabled: false, envKeys: []};
     }
 
@@ -157,11 +157,11 @@ function normalizeSectionCacheConfig(sectionName, value, resolvedPatterns) {
         );
     }
 
-    if (value.enabled !== undefined && typeof value.enabled !== "boolean") {
+    if (value.enabled !== void 0 && typeof value.enabled !== "boolean") {
         throw new Error(`Config section "${sectionName}" cache enabled must be a boolean.`);
     }
 
-    const envKeys = value.envKeys === undefined
+    const envKeys = value.envKeys === void 0
         ? []
         : normalizeCacheStringList(`section "${sectionName}" cache`, "envKeys", value.envKeys);
 
@@ -260,15 +260,21 @@ function normalizeSectionCommandList(sectionName, value, sectionOutput) {
     for (const entry of value) {
         if (typeof entry === "string") {
             const trimmed = entry.trim();
-            if (trimmed.length > 0) {
-                commands.push(normalizeCommandObject(sectionName, {cmd: trimmed}, sectionOutput));
-            }
+            pushNonEmptyCommand(commands, sectionName, trimmed, sectionOutput);
             continue;
         }
 
         commands.push(normalizeCommandObject(sectionName, entry, sectionOutput));
     }
     return commands;
+}
+
+function pushNonEmptyCommand(commands, sectionName, command, sectionOutput) {
+    if (command.length === 0) {
+        return;
+    }
+
+    commands.push(normalizeCommandObject(sectionName, {cmd: command}, sectionOutput));
 }
 
 function normalizeCommandObject(sectionName, entry, sectionOutput) {
@@ -292,7 +298,7 @@ function normalizeCommandObject(sectionName, entry, sectionOutput) {
         stripAnsi: entry.stripAnsi,
     });
 
-    if (entry.cache !== undefined) {
+    if (entry.cache !== void 0) {
         throw new Error(`Config section "${sectionName}" command cache is not supported. Configure cache at section level.`);
     }
 
@@ -348,7 +354,7 @@ function normalizeOutputConfig(context, value) {
     }
 
     const normalized = {};
-    if (value.outputMode !== undefined) {
+    if (value.outputMode !== void 0) {
         if (typeof value.outputMode !== "string" || !OUTPUT_MODES.has(value.outputMode)) {
             throw new Error(
                 `Config ${context} outputMode must be one of: ${[...OUTPUT_MODES].join(", ")}.`
@@ -357,26 +363,26 @@ function normalizeOutputConfig(context, value) {
         normalized.outputMode = value.outputMode;
     }
 
-    if (value.failTailLines !== undefined) {
+    if (value.failTailLines !== void 0) {
         normalized.failTailLines = normalizePositiveInteger(context, "failTailLines", value.failTailLines);
     }
 
-    if (value.maxOutputBytes !== undefined) {
+    if (value.maxOutputBytes !== void 0) {
         normalized.maxOutputBytes = normalizePositiveInteger(context, "maxOutputBytes", value.maxOutputBytes);
     }
 
-    if (value.stripAnsi !== undefined) {
+    if (value.stripAnsi !== void 0) {
         if (typeof value.stripAnsi !== "boolean") {
             throw new Error(`Config ${context} stripAnsi must be a boolean.`);
         }
         normalized.stripAnsi = value.stripAnsi;
     }
 
-    if (value.parser !== undefined) {
+    if (value.parser !== void 0) {
         normalized.parser = normalizeParser(context, value.parser);
     }
 
-    if (value.parserInputBytes !== undefined) {
+    if (value.parserInputBytes !== void 0) {
         normalized.parserInputBytes = normalizePositiveInteger(context, "parserInputBytes", value.parserInputBytes);
     }
 

--- a/.agents/skills/qa-run/scripts/run-matrix/parsers/phpstan-json.mjs
+++ b/.agents/skills/qa-run/scripts/run-matrix/parsers/phpstan-json.mjs
@@ -18,25 +18,25 @@ function parsePhpStanJson(text) {
 
     const lines = [];
     if (Array.isArray(parsed.errors)) {
-        for (const error of parsed.errors) {
-            if (typeof error === "string") {
-                lines.push(error);
-            }
-        }
+        lines.push(...parsed.errors.filter((error) => typeof error === "string"));
     }
 
     if (parsed.files && typeof parsed.files === "object" && !Array.isArray(parsed.files)) {
         for (const [filePath, fileReport] of Object.entries(parsed.files)) {
-            const messages = Array.isArray(fileReport?.messages) ? fileReport.messages : [];
-            for (const message of messages) {
-                const line = Number.isInteger(message?.line) ? `:${message.line}` : "";
-                const textMessage = typeof message?.message === "string" ? message.message : JSON.stringify(message);
-                lines.push(`${filePath}${line} ${textMessage}`);
-            }
+            lines.push(...formatFileMessages(filePath, fileReport));
         }
     }
 
     return lines;
+}
+
+function formatFileMessages(filePath, fileReport) {
+    const messages = Array.isArray(fileReport?.messages) ? fileReport.messages : [];
+    return messages.map((message) => {
+        const line = Number.isInteger(message?.line) ? `:${message.line}` : "";
+        const textMessage = typeof message?.message === "string" ? message.message : JSON.stringify(message);
+        return `${filePath}${line} ${textMessage}`;
+    });
 }
 
 export {

--- a/.agents/skills/qa-run/scripts/run-matrix/reporting/summary-writer.mjs
+++ b/.agents/skills/qa-run/scripts/run-matrix/reporting/summary-writer.mjs
@@ -69,10 +69,7 @@ export function renderSummaryText(summary) {
     } else {
         lines.push("Failures:");
         for (const failure of summary.failures) {
-            lines.push(`- [${failure.section}] ${failure.command} exit=${failure.exitCode}`);
-            for (const detail of failure.summary) {
-                lines.push(`  - ${detail}`);
-            }
+            appendFailureLines(lines, failure);
         }
     }
 
@@ -85,4 +82,9 @@ export function renderSummaryText(summary) {
 
     lines.push("");
     return `${lines.join("\n")}\n`;
+}
+
+function appendFailureLines(lines, failure) {
+    lines.push(`- [${failure.section}] ${failure.command} exit=${failure.exitCode}`);
+    lines.push(...failure.summary.map((detail) => `  - ${detail}`));
 }

--- a/.agents/skills/qa-run/templates/qa-run.matrix.dist.json
+++ b/.agents/skills/qa-run/templates/qa-run.matrix.dist.json
@@ -34,10 +34,10 @@
         "ALWAYS_FULL": {
             "patterns": [],
             "commands": [
-                "./bin/proxy/yarn lint:yarn:dedupe:fix",
-                "./bin/proxy/yarn lint:yarn:dedupe",
-                "./bin/proxy/composer lint:composer:security",
-                "./bin/proxy/yarn lint:yarn:security"
+                "./bin/proxy/yarn --proxy-quiet lint:yarn:dedupe:fix",
+                "./bin/proxy/yarn --proxy-quiet lint:yarn:dedupe",
+                "./bin/proxy/composer --proxy-quiet lint:composer:security",
+                "./bin/proxy/yarn --proxy-quiet lint:yarn:security"
             ],
             "runOn": [
                 "full"
@@ -60,8 +60,8 @@
                 "yarn.lock"
             ],
             "commands": [
-                "./bin/proxy/composer lint:composer:dependency",
-                "./bin/proxy/composer lint:composer:normalize:fix"
+                "./bin/proxy/composer --proxy-quiet lint:composer:dependency",
+                "./bin/proxy/composer --proxy-quiet lint:composer:normalize:fix"
             ],
             "runOn": [
                 "full",
@@ -80,16 +80,16 @@
                 "failTailLines": 160
             },
             "commands": [
-                "./bin/proxy/composer dump-autoload",
-                "./bin/proxy/console lint:container",
-                "./bin/proxy/console app:deptrac-config:generate",
-                "./bin/proxy/composer lint:deptrac",
+                "./bin/proxy/composer --proxy-quiet dump-autoload",
+                "./bin/proxy/console --proxy-quiet lint:container",
+                "./bin/proxy/console --proxy-quiet app:deptrac-config:generate",
+                "./bin/proxy/composer --proxy-quiet lint:deptrac",
                 {
-                    "cmd": "./bin/proxy/composer lint:phpstan -- --error-format=json",
+                    "cmd": "./bin/proxy/composer --proxy-quiet lint:phpstan -- --error-format=json",
                     "parser": "phpstan-json"
                 },
-                "./bin/proxy/composer lint:php:fix",
-                "./bin/proxy/composer test"
+                "./bin/proxy/composer --proxy-quiet lint:php:fix",
+                "./bin/proxy/composer --proxy-quiet test"
             ],
             "runOn": [
                 "full",
@@ -102,8 +102,8 @@
                 "**/*.twig"
             ],
             "commands": [
-                "./bin/proxy/composer lint:twig:fix",
-                "./bin/proxy/composer lint:twig"
+                "./bin/proxy/composer --proxy-quiet lint:twig:fix",
+                "./bin/proxy/composer --proxy-quiet lint:twig"
             ],
             "runOn": [
                 "full",
@@ -119,9 +119,15 @@
                 "enabled": true
             },
             "commands": [
-                "./bin/proxy/yarn lint:js:fix",
-                "./bin/proxy/yarn lint:js",
-                "./bin/proxy/yarn lint:ts:typecheck"
+                {
+                    "cmd": "./bin/proxy/yarn --proxy-quiet lint:js:fix --format json",
+                    "parser": "eslint-json"
+                },
+                {
+                    "cmd": "./bin/proxy/yarn --proxy-quiet lint:js --format json",
+                    "parser": "eslint-json"
+                },
+                "./bin/proxy/yarn --proxy-quiet lint:ts:typecheck"
             ],
             "runOn": [
                 "full",
@@ -135,8 +141,8 @@
                 "**/*.scss"
             ],
             "commands": [
-                "./bin/proxy/yarn lint:style:fix",
-                "./bin/proxy/yarn lint:style"
+                "./bin/proxy/yarn --proxy-quiet lint:style:fix",
+                "./bin/proxy/yarn --proxy-quiet lint:style"
             ],
             "runOn": [
                 "full",
@@ -150,7 +156,7 @@
                 "src/*/UI/Translation/**"
             ],
             "commands": [
-                "./bin/proxy/composer lint:translations"
+                "./bin/proxy/composer --proxy-quiet lint:translations"
             ],
             "runOn": [
                 "full",
@@ -164,7 +170,7 @@
                 "**/*.yaml"
             ],
             "commands": [
-                "./bin/proxy/composer lint:yaml"
+                "./bin/proxy/composer --proxy-quiet lint:yaml"
             ],
             "runOn": [
                 "full",

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -12,6 +12,7 @@
 - `$gh-issue-status-set`
 - `$git-commit`
 - `$handoff-refresh`
+- `$php-structure-refactor`
 - `$qa-run`
 - `$review-quick`
 - `$rules-sync`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,12 +3,6 @@ import eslint from "@eslint/js";
 import globals from "globals";
 import stylistic from "@stylistic/eslint-plugin";
 
-const jsFiles = [
-    "eslint.config.mjs",
-    ".agents/skills/qa-run/scripts/**/*.mjs",
-    "tests/skills/qa-run/**/*.mjs",
-];
-
 // https://eslint.style/rules
 // https://eslint.org/docs/latest/rules/
 const additionalRules = {
@@ -21,6 +15,7 @@ const additionalRules = {
     "require-atomic-updates": "error",
     "block-scoped-var": "error",
     "camelcase": "error",
+    "complexity": "error",
     "consistent-return": "error",
     "curly": "error",
     "default-case-last": "error",
@@ -29,6 +24,7 @@ const additionalRules = {
     "eqeqeq": "error",
     "guard-for-in": "error",
     "max-classes-per-file": "error",
+    "max-depth": ["error", {"max": 2}],
     "no-alert": "error",
     "no-else-return": "error",
     "no-empty": "error",
@@ -47,6 +43,7 @@ const additionalRules = {
     "no-sequences": "error",
     "no-shadow": "error",
     "no-throw-literal": "error",
+    "no-undefined": "error",
     "no-unneeded-ternary": "error",
     "no-unused-expressions": "error",
     "no-useless-constructor": "error",
@@ -87,7 +84,7 @@ export default defineConfig([
     {
         ...eslint.configs.recommended,
         ...stylistic.configs.recommended,
-        files: jsFiles,
+        files: ["**/*.{js,mjs,cjs}"],
         languageOptions: {
             ecmaVersion: "latest",
             sourceType: "module",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
     "type": "module",
     "scripts": {
         "lint:js": "eslint",
+        "lint:js:fix": "eslint --fix",
+        "lint:js:fix:dry": "eslint --fix-dry-run",
         "test": "vitest run"
     },
     "devDependencies": {

--- a/tests/skills/qa-run/run-matrix.test.mjs
+++ b/tests/skills/qa-run/run-matrix.test.mjs
@@ -337,7 +337,57 @@ describe("run-matrix output contract", () => {
 
             expect(config.sectionOrder.length, matrixPath).toBeGreaterThan(0);
             expect(Object.keys(config.sections).sort(), matrixPath).toEqual([...config.sectionOrder].sort());
+            expect(config.sectionOrder, matrixPath).toContain("JS_TS_CHANGED");
+            expect(config.patternSets["project-js-ts-checks"], matrixPath).toEqual(["@js-ts-safe"]);
+            expect(config.sections.JS_TS_CHANGED.patterns, matrixPath).toEqual(["@project-js-ts-checks"]);
+            expect(config.sections.JS_TS_CHANGED.resolvedPatterns.patternSets, matrixPath).toEqual(expect.arrayContaining([
+                "@js-ts-safe",
+                "@project-js-ts-checks",
+            ]));
+            expect(config.sections.JS_TS_CHANGED.resolvedPatterns.patterns, matrixPath).toEqual(expect.arrayContaining([
+                "**/*.mjs",
+                "eslint.config.*",
+                "tests/**/*.mjs",
+            ]));
+            expect(config.sections.JS_TS_CHANGED.commands, matrixPath).toEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    cmd: expect.stringContaining("--format json"),
+                    output: expect.objectContaining({
+                        parser: "eslint-json",
+                    }),
+                }),
+            ]));
         }
+    });
+
+    it("keeps bundled dist machine-output commands aligned with current proxy contract", () => {
+        const config = parseConfig(
+            readFileSync(path.join(repoRoot, ".agents/skills/qa-run/templates/qa-run.matrix.dist.json"), "utf-8"),
+            ".agents/skills/qa-run/templates/qa-run.matrix.dist.json"
+        );
+
+        expect(config.sections.PHP_CHANGED.commands).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                cmd: "./bin/proxy/composer --proxy-quiet lint:phpstan -- --error-format=json",
+                output: expect.objectContaining({
+                    parser: "phpstan-json",
+                }),
+            }),
+        ]));
+        expect(config.sections.JS_TS_CHANGED.commands).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                cmd: "./bin/proxy/yarn --proxy-quiet lint:js:fix --format json",
+                output: expect.objectContaining({
+                    parser: "eslint-json",
+                }),
+            }),
+            expect.objectContaining({
+                cmd: "./bin/proxy/yarn --proxy-quiet lint:js --format json",
+                output: expect.objectContaining({
+                    parser: "eslint-json",
+                }),
+            }),
+        ]));
     });
 
     it("rejects unknown parser names in command output config", () => {

--- a/tests/skills/qa-run/snapshot.test.mjs
+++ b/tests/skills/qa-run/snapshot.test.mjs
@@ -23,7 +23,7 @@ afterEach(() => {
 describe("snapshot change detection", () => {
     it("compares missing and present file fingerprints", () => {
         expect(fingerprintEquals(null, null)).toBe(true);
-        expect(fingerprintEquals(undefined, undefined)).toBe(true);
+        expect(fingerprintEquals(void 0, void 0)).toBe(true);
         expect(fingerprintEquals(null, {exists: true, hash: "abc"})).toBe(false);
         expect(fingerprintEquals({exists: false, hash: null}, {exists: false, hash: null})).toBe(true);
         expect(fingerprintEquals({exists: true, hash: "abc"}, {exists: true, hash: "abc"})).toBe(true);


### PR DESCRIPTION
- dodano delegację z code-implement do php-structure-refactor dla operacji strukturalnych na PHP
- rozszerzono opis php-structure-refactor o szersze triggery Phpactora, Rectora i php-cs-fixer
- zaostrzono ESLint dla skryptów JS i dostosowano helpery qa-run oraz php-structure-refactor do nowych reguł
- zaktualizowano macierz qa-run i template dist o parsery JSON oraz komendy proxy-quiet
- dodano testy kontraktu JS_TS_CHANGED, parserów JSON i template qa-run
- odświeżono indeks skilli o php-structure-refactor