### PR TITLE
feat: dodanie atlasu modułów i ujednolicenie docs_map

### DIFF
--- a/.agents/skills/context-refresh/SKILL.md
+++ b/.agents/skills/context-refresh/SKILL.md
@@ -49,6 +49,7 @@ Ten skill ma dwa tryby wykonania. Domyślny jest **Quick**, a **Full** uruchamia
 ### Tryb Quick (domyślny)
 Cel: szybko uzyskać bezpieczny kontekst do pracy bez ładowania całej dokumentacji.
 - Czyta “rdzeń” dokumentacji (procedury/zasady/indeksy) zawsze.
+- Jeśli zdefiniowano `MODULE_INDEX_DOC`, czyta go jako lekki atlas modułów i ich ról.
 - Dokumentację modułów (jeśli zdefiniowano `MODULE_DOCS_GLOB`) czyta tylko dla modułów dotkniętych zmianami lub wskazanych w prompt.
 - README testów (jeśli zdefiniowano `TESTS_README`) czyta tylko, jeśli zmiany dotyczą testów lub ich uruchamiania.
 - Analizę zmian w repo robi “skalowalnie” i **doczytuje szczegóły dopiero wtedy, gdy są potrzebne do zadania** (on-demand).
@@ -100,8 +101,20 @@ Przeczytaj w całości (to jest minimalny “rdzeń” reguł i konwencji):
 10. Odczytaj `HANDOFF_DOC` — jeśli zdefiniowano.
 
 ### 3) Dokumentacja modułowa (lazy, ale bezpiecznie)
-1. Jeśli zdefiniowano `MODULE_DOCS_GLOB` i `git diff --name-only` zawiera zmiany w modułach, przeczytaj README dokumentacji dla każdego dotkniętego modułu.
-2. Jeśli tryb to **Full** i zdefiniowano `MODULE_DOCS_GLOB`, przeczytaj README dokumentacji dla wszystkich modułów; jeśli zdefiniowano `MODULE_INDEX_DOC`, użyj go jako indeksu.
+1. Jeśli zdefiniowano `MODULE_INDEX_DOC`, przeczytaj go jako mapę orientacyjną przed doczytywaniem szczegółów.
+2. Jeśli zdefiniowano `MODULE_DOCS_GLOB` i `git diff --name-only` zawiera zmiany w modułach, przeczytaj README dokumentacji tylko dla dotkniętych modułów.
+3. Jeśli aktualny moduł ma użyć funkcjonalności z innego modułu albo prompt wymaga decyzji między modułami, doczytaj też dokumentację tego drugiego modułu.
+4. Jeśli tryb to **Full** i zdefiniowano `MODULE_DOCS_GLOB`, doczytuj szerzej, ale nadal zaczynaj od atlasu (`MODULE_INDEX_DOC`) i rozszerzaj zakres tylko wtedy, gdy jest to potrzebne do zadania.
+
+### 3a) Jak interpretować `MODULE_INDEX_DOC`
+Jeśli atlas modułów istnieje, traktuj go jako warstwę decyzyjną:
+1. Z każdego wpisu wyciągnij tylko cztery rzeczy: rolę modułu, punkty wejścia, powiązania i sygnały `Czytać, gdy` / `Nie czytać, gdy`.
+2. Na tej podstawie wybierz:
+   - moduł główny, który jest bezpośrednio dotknięty zadaniem,
+   - maksymalnie 0-2 moduły pomocnicze, jeśli atlas wskazuje zależność albo współużycie funkcjonalności.
+3. Doczytaj pełne README tylko dla wybranych modułów, a nie dla całego atlasu.
+4. Jeśli atlas mówi `Nie czytać, gdy`, nie ładuj pełnej dokumentacji danego modułu bez dodatkowego triggera z promptu, diffu albo decyzji architektonicznej.
+5. Jeśli wpis atlasu jest zbyt ogólny albo sprzeczny z innymi źródłami, zanotuj to w uwagach i oprzyj decyzję na pełnej dokumentacji modułu oraz `MAIN_DOC`.
 
 ### 4) Testy (lazy)
 Jeśli zdefiniowano `TESTS_README` i zmiany dotyczą testów lub sposobu ich uruchamiania (np. `tests/`, `codeception`, `make test.*`, wrapper `codecept` z `BIN_PATH`), przeczytaj README testów.
@@ -122,6 +135,7 @@ Cel: zrozumieć, “co jest zmienione w repo” bez konieczności wklejania duż
    - prompt wprost wymienia ścieżkę pliku (np. `src/.../Foo.php`) → przeczytaj ten plik i jego diff (jeśli ma),
    - prompt wprost wymienia symbol (klasa/metoda/komenda/route) → znajdź definicję (`rg`) i przeczytaj definicję + kontekst,
    - masz zmienić plik, który już jest zmieniony w repo (czyli “modyfikujesz cudze/bieżące zmiany”) → przeczytaj jego diff i aktualną treść przed edycją,
+   - aktualny moduł ma użyć funkcjonalności z innego modułu → doczytaj dokumentację obu modułów, zaczynając od `MODULE_INDEX_DOC`, jeśli istnieje,
    - masz przygotować treść commita (`$commit-message-write`) → upewnij się, że rozumiesz “co” i “dlaczego” (diff/kluczowe fragmenty),
    - QA/testy zwróciły błąd w pliku, którego nie analizowałeś → doczytaj od razu ten plik i sąsiedni kontekst,
    - pojawia się decyzja architektoniczna/domenowa, a nie czytałeś dokumentacji modułu/domeny dotkniętej zmianą → doczytaj README modułu (z `MODULE_DOCS_GLOB`) i relewantny fragment `MAIN_DOC`.

--- a/.agents/skills/gh-issue-start/scripts/start.sh
+++ b/.agents/skills/gh-issue-start/scripts/start.sh
@@ -171,11 +171,6 @@ if [ -z "$issue_number" ]; then
   issue_title="$title"
 fi
 
-slug="$(slugify "$issue_title")"
-if [ -z "$slug" ]; then
-  slug="issue"
-fi
-
 branch_name="$(issue_branch_make "$issue_number" "$issue_title")"
 
 remote="origin"

--- a/.agents/skills/module-atlas-sync/SKILL.md
+++ b/.agents/skills/module-atlas-sync/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: module-atlas-sync
+description: >-
+  Utrzymuj atlas modułów wskazany przez `MODULE_INDEX_DOC` jako zwięzłą mapę
+  ról modułów: pilnuj ról modułów, punktów wejścia, powiązań, API modułów oraz
+  odnośników do `MAIN_DOC` i README modułów wskazanych przez
+  `MODULE_DOCS_GLOB`. Używaj, gdy zmienia się struktura modułów, dokumentacja
+  modułów, relacje między modułami, publiczne API modułów albo gdy trzeba
+  świadomie zaktualizować atlas.
+shared_files:
+  - _shared/references/runtime-collaboration-guidelines.md
+  - _shared/scripts/env-load.sh
+---
+
+# $module-atlas-sync
+
+## Reguły rozwiązywania ścieżek
+- Stosuj globalny kontrakt ścieżek z root `AGENTS.md`.
+
+## Priorytet zasad (globalny kontrakt)
+1. Instrukcje systemowe/developerskie środowiska
+2. `./AGENTS.md` i dokumenty z `docs_map`
+3. Bieżący `SKILL.md`
+4. Pliki wskazane w `shared_files`
+
+## Cel
+Utrzymuj i aktualizuj atlas modułów wskazany przez `MODULE_INDEX_DOC` tak, aby
+był krótki, dokładny i łatwy do skanowania. Głównym wynikiem pracy skilla jest
+zawsze zaktualizowany atlas modułów. Atlas jest warstwą orientacyjną, a nie
+zamiennikiem pełnej dokumentacji modułów.
+
+## Wymagane klucze dokumentacji (docs_map)
+- Wymagane:
+  - `MAIN_DOC`: główny dokument projektu.
+  - `MODULE_INDEX_DOC`: plik atlasu modułów do aktualizacji.
+  - `MODULE_DOCS_GLOB`: glob dla README dokumentacji modułów.
+
+## Kiedy używać
+- Gdy moduł został dodany, usunięty, przemianowany albo zmienił zakres.
+- Gdy zmieniła się struktura modułów, dokumentacja modułów, relacje między modułami, publiczne API albo punkty wejścia modułów.
+- Gdy atlas modułów wymaga sprawdzenia spójności względem `MAIN_DOC` i dokumentacji modułów.
+
+## Przepływ
+1. Otwórz `AGENTS.md` i odczytaj `docs_map`.
+2. Odczytaj `MAIN_DOC`, `MODULE_INDEX_DOC` i `MODULE_DOCS_GLOB`.
+3. Jeśli mapy lub któregoś z wymaganych kluczy brakuje, zatrzymaj się i dopytaj użytkownika.
+4. Przeczytaj `MAIN_DOC` i `MODULE_INDEX_DOC`.
+5. Dla każdego dotkniętego modułu przeczytaj tylko odpowiedni README znaleziony przez `MODULE_DOCS_GLOB`.
+6. Jeśli `MODULE_INDEX_DOC` nie istnieje, utwórz go razem z brakującymi katalogami nadrzędnymi.
+7. Porównaj wpisy z poniższym szablonem i doprowadź atlas do zgodności.
+8. Preferuj skracanie albo usuwanie treści zamiast dopisywania kolejnych akapitów.
+9. Jeśli czegoś nie da się podeprzeć dokumentacją repo albo kodem, pomiń to i oznacz jako follow-up.
+
+## Sztywny szablon wpisu
+Każdy moduł w atlasie wskazanym przez `MODULE_INDEX_DOC` zapisuj dokładnie w tym układzie:
+
+```md
+- [Nazwa](../src/Nazwa/Docs/README.md) — <jednozdaniowa rola modułu>.
+  - Punkty wejścia: <krótka lista lub `brak potwierdzonych`>
+  - Powiązania: <krótka lista modułów lub `brak potwierdzonych`>
+  - Czytać, gdy: <krótka lista sytuacji>
+  - Nie czytać, gdy: <krótka lista sytuacji>
+  - Główna dokumentacja: `<MAIN_DOC>`, `<README modułu>`
+```
+
+Zasady wpisów:
+- Jeden wpis na jeden moduł.
+- Opisy mają być krótkie i skanowalne.
+- Nie duplikuj w atlasie pełnej dokumentacji modułu.
+- Używaj atlasu do wyboru kolejnych dokumentów do czytania, nie jako zamiennika tych dokumentów.
+
+## Szybkie kontrole
+- `rg -n "^-" <MODULE_INDEX_DOC>`
+- `rg -n "README.md|src/.*/Docs/README.md" <MODULE_INDEX_DOC>`
+
+## Oczekiwany wynik
+Najpierw zapisz zaktualizowany plik wskazany przez `MODULE_INDEX_DOC`, a dopiero potem zwróć zwięzły raport o znalezionych uszkodzonych linkach, nieaktualnych opisach, brakujących modułach albo lukach w powiązaniach.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,20 @@ Use this block in project `AGENTS.md`:
 docs_map:
     MAIN_DOC: docs/README.md
     AGENT_RULES_DOC: AGENTS.md
+    MODULE_INDEX_DOC: docs/modules/README.md
+    MODULE_DOCS_GLOB: docs/modules/*/README.md
+    COMMIT_MESSAGE_DIR: /tmp/
+    HANDOFF_DOC: var/agent/HANDOFF.md
+    SKILLS_INDEX_DOC: docs/SKILLS.md
+```
+
+## Active docs_map
+```yaml
+docs_map:
+    MAIN_DOC: docs/README.md
+    AGENT_RULES_DOC: AGENTS.md
+    MODULE_INDEX_DOC: docs/modules/README.md
+    MODULE_DOCS_GLOB: docs/modules/*/README.md
     COMMIT_MESSAGE_DIR: /tmp/
     HANDOFF_DOC: var/agent/HANDOFF.md
     SKILLS_INDEX_DOC: docs/SKILLS.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation
+
+This repository stores reusable LLM skills under `.agents/skills/`.
+
+## Scope
+- Skill instructions live in `.agents/skills/<skill-name>/SKILL.md`.
+- Optional helper scripts live in `.agents/skills/<skill-name>/scripts/`.
+- Tests for repository tooling live in `tests/skills/`.
+
+## Documentation Map
+- [Skills index](./SKILLS.md)
+- [Module index](./modules/README.md)
+
+## Notes
+- This repo does not define application modules like a business monolith.
+- The module index is kept for compatibility with shared documentation skills.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -12,6 +12,7 @@
 - `$gh-issue-status-set`
 - `$git-commit`
 - `$handoff-refresh`
+- `$module-atlas-sync`
 - `$php-structure-refactor`
 - `$qa-run`
 - `$review-quick`

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,8 @@
+# Module Index
+
+This repository does not currently define module-level documentation entries under `docs/modules/*/README.md`.
+
+The index exists to satisfy shared documentation workflows that expect:
+- a main documentation document,
+- a module index document,
+- an optional set of module README files matched by `MODULE_DOCS_GLOB`.


### PR DESCRIPTION
## Zmiany ogólne
- Rozszerzono `context-refresh` o wykorzystanie `MODULE_INDEX_DOC` jako lekkiego atlasu modułów i doprecyzowano, kiedy doczytywać dokumentację modułów pomocniczych.
- Dodano skill `$module-atlas-sync` oraz wpis w `docs/SKILLS.md`.
- Usunięto martwe wyliczanie `slug` z helpera startującego pracę nad issue i pozostawiono generowanie nazwy brancha we wspólnym helperze.
- Ujednolicono kontrakt `docs_map` w `AGENTS.md` oraz dodano minimalne `docs/README.md` i `docs/modules/README.md`, żeby wspólne skille dokumentacyjne miały komplet wymaganych punktów wejścia.