### PR TITLE
fix: zabezpieczono start pracy i statusy projektów

### DIFF
--- a/.agents/skills/_shared/scripts/worktree.mjs
+++ b/.agents/skills/_shared/scripts/worktree.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+import {readSync} from "node:fs";
+
+export const DIRTY_TREE_STRATEGIES = [
+    {
+        id: "stash",
+        label: "Stashuj zmiany",
+        description: "Zachowaj zmiany w stashu i utwórz czysty branch z bazy.",
+    },
+    {
+        id: "commit-wip",
+        label: "Zapisz commit WIP na bieżącym branchu",
+        description: "Dodaj wszystkie bieżące zmiany do commita WIP, potem utwórz branch z bazy.",
+    },
+    {
+        id: "move-to-new-branch",
+        label: "Przenieś zmiany na nowy branch",
+        description: "Utwórz branch z bazy i zastosuj na nim bieżące zmiany.",
+    },
+    {
+        id: "other",
+        label: "Inne",
+        description: "Wpisz własną instrukcję dla agenta.",
+    },
+];
+
+const STRATEGY_IDS = new Set(DIRTY_TREE_STRATEGIES.map(({id}) => id));
+
+export function run(command, args, execCommand) {
+    const result = execCommand(command, args);
+    return {
+        code: result.status ?? 1,
+        stderr: String(result.stderr ?? ""),
+        stdout: String(result.stdout ?? ""),
+    };
+}
+
+export function commandFailure(command, args, result) {
+    const details = result.stderr.trim() || result.stdout.trim() || `kod wyjścia ${result.code}`;
+    return `Nie udało się wykonać: ${command} ${args.join(" ")} (${details}).`;
+}
+
+export function getDirtyTreeStatus(execCommand) {
+    const result = run("git", ["status", "--porcelain=v1", "-uall"], execCommand);
+
+    if (result.code !== 0) {
+        return {code: result.code, stderr: commandFailure("git", ["status", "--porcelain=v1", "-uall"], result)};
+    }
+
+    return {code: 0, dirty: Boolean(result.stdout.trim()), output: result.stdout};
+}
+
+export function normalizeDirtyTreeStrategy(value) {
+    const strategy = String(value ?? "").trim().toLowerCase();
+    return STRATEGY_IDS.has(strategy) ? strategy : "";
+}
+
+function readByte(read, fd) {
+    const buffer = Buffer.alloc(1);
+    const bytesRead = read(fd, buffer, 0, 1, null);
+    return bytesRead > 0 ? buffer[0] : null;
+}
+
+function readKey(read, fd) {
+    const first = readByte(read, fd);
+    if (first === null) {
+        return "";
+    }
+
+    if (first !== 0x1b) {
+        return String.fromCharCode(first);
+    }
+
+    const second = readByte(read, fd);
+    const third = readByte(read, fd);
+    if (second === 0x5b && third === 0x41) { return "up"; }
+    if (second === 0x5b && third === 0x42) { return "down"; }
+    return "escape";
+}
+
+function readLine(read, fd) {
+    const characters = [];
+    let character;
+    while ((character = readByte(read, fd)) !== null) {
+        if (character === 0x0a || character === 0x0d) {
+            break;
+        }
+        characters.push(String.fromCharCode(character));
+    }
+    return characters.join("").trim();
+}
+
+function resolveSelectedStrategy({input, output, read, strategy}) {
+    if (strategy.id !== "other") {
+        return {code: 0, strategy: strategy.id};
+    }
+
+    input.setRawMode(false);
+    output.write("Wpisz instrukcję dla agenta: ");
+    const instruction = readLine(read, input.fd ?? 0);
+    return {
+        code: instruction ? 16 : 14,
+        instruction,
+        stderr: instruction ? "" : "Nie podano instrukcji dla opcji Inne.",
+    };
+}
+
+export function promptDirtyTreeStrategy({input, output, read = readSync} = {}) {
+    const stdin = input ?? process.stdin;
+    const stdout = output ?? process.stdout;
+
+    if (!stdin.isTTY || !stdout.isTTY || typeof stdin.setRawMode !== "function") {
+        return {
+            code: 14,
+            stderr: "Dirty tree wykryty, ale wejście nie jest interaktywne. Użyj --dirty-strategy <stash|commit-wip|move-to-new-branch|other>.",
+        };
+    }
+
+    let selected = 0;
+    const render = () => {
+        stdout.write("\nWykryto bieżące zmiany. Wybierz sposób ich obsługi (strzałki + Enter):\n");
+        DIRTY_TREE_STRATEGIES.forEach((strategy, index) => {
+            const marker = index === selected ? "❯" : " ";
+            stdout.write(`${marker} ${strategy.label} — ${strategy.description}\n`);
+        });
+    };
+
+    const previousRawMode = stdin.isRaw ?? false;
+    stdin.setRawMode(true);
+    stdin.resume();
+
+    try {
+        render();
+        while (true) {
+            const key = readKey(read, stdin.fd ?? 0);
+            if (key === "up") {
+                selected = (selected + DIRTY_TREE_STRATEGIES.length - 1) % DIRTY_TREE_STRATEGIES.length;
+                render();
+            } else if (key === "down") {
+                selected = (selected + 1) % DIRTY_TREE_STRATEGIES.length;
+                render();
+            } else if (key === "\r" || key === "\n") {
+                return resolveSelectedStrategy({input: stdin, output: stdout, read, strategy: DIRTY_TREE_STRATEGIES[selected]});
+            } else if (key === "\u0003" || key === "escape") {
+                return {code: 130, stderr: "Anulowano wybór obsługi dirty tree."};
+            }
+        }
+    } finally {
+        stdin.setRawMode(previousRawMode);
+    }
+}
+
+export function checkoutBranch({branchName, baseRef, remote, execCommand}) {
+    const branchExists = run("git", ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`], execCommand).code === 0;
+    const remoteBranchExists = run("git", ["show-ref", "--verify", "--quiet", `refs/remotes/${remote}/${branchName}`], execCommand).code === 0;
+    const args = branchExists
+        ? ["checkout", branchName]
+        : remoteBranchExists
+            ? ["checkout", "-b", branchName, "--track", `${remote}/${branchName}`]
+            : ["checkout", "-b", branchName, baseRef];
+    const result = run("git", args, execCommand);
+
+    if (result.code !== 0) {
+        return {code: 15, stderr: commandFailure("git", args, result)};
+    }
+
+    const currentBranch = run("git", ["branch", "--show-current"], execCommand);
+    if (currentBranch.code !== 0 || currentBranch.stdout.trim() !== branchName) {
+        return {
+            code: 15,
+            stderr: `Checkout nie został potwierdzony. Oczekiwano '${branchName}', aktywny branch to '${currentBranch.stdout.trim() || "nieznany"}'.`,
+        };
+    }
+
+    return {code: 0, branchName};
+}
+
+export function applyDirtyTreeStrategy({strategy, issueNumber, branchName, baseRef, remote, execCommand}) {
+    const message = `wip: preserve changes before issue #${issueNumber}`;
+    let stashCreated = false;
+
+    if (strategy === "stash" || strategy === "move-to-new-branch") {
+        const stash = run("git", ["stash", "push", "--include-untracked", "-m", message], execCommand);
+        if (stash.code !== 0) {
+            return {code: 15, stderr: commandFailure("git", ["stash", "push", "--include-untracked", "-m", message], stash)};
+        }
+        stashCreated = true;
+    } else if (strategy === "commit-wip") {
+        const add = run("git", ["add", "-A"], execCommand);
+        if (add.code !== 0) {
+            return {code: 15, stderr: commandFailure("git", ["add", "-A"], add)};
+        }
+        const commit = run("git", ["commit", "-m", message], execCommand);
+        if (commit.code !== 0) {
+            return {code: 15, stderr: commandFailure("git", ["commit", "-m", message], commit)};
+        }
+    }
+
+    const checkout = checkoutBranch({branchName, baseRef, remote, execCommand});
+    if (checkout.code !== 0) {
+        return {...checkout, stashCreated};
+    }
+    if (strategy === "stash") {
+        return {code: 0, branchName, stashCreated};
+    }
+
+    if (strategy === "move-to-new-branch") {
+        const apply = run("git", ["stash", "apply"], execCommand);
+        if (apply.code !== 0) {
+            return {
+                code: 15,
+                stashCreated: true,
+                stderr: `${commandFailure("git", ["stash", "apply"], apply)} Stash pozostawiono do ręcznego odzyskania.`,
+            };
+        }
+        const drop = run("git", ["stash", "drop"], execCommand);
+        if (drop.code !== 0) {
+            return {
+                code: 15,
+                stashCreated: true,
+                stderr: `${commandFailure("git", ["stash", "drop"], drop)} Zastosowane zmiany pozostają na branchu, ale stash nie został usunięty.`,
+            };
+        }
+    }
+
+    return {code: 0, branchName, stashCreated};
+}

--- a/.agents/skills/gh-issue-start/SKILL.md
+++ b/.agents/skills/gh-issue-start/SKILL.md
@@ -7,6 +7,7 @@ shared_files:
   - _shared/references/runtime-collaboration-guidelines.md
   - _shared/scripts/env-load.sh
   - _shared/scripts/issue-branch.mjs
+  - _shared/scripts/worktree.mjs
 ---
 
 # $gh-issue-start
@@ -32,12 +33,18 @@ Zautomatyzować start pracy nad issue: ustalenie numeru issue, utworzenie/checko
    - `<skill_dir>/scripts/start.mjs`
    - Opcje:
      - `--issue-number <NUMER>`
-     - `--title "<Tytuł>"` (używane, gdy trzeba utworzyć nowe issue)
-     - `--desc "<Opis>"` (krótki opis do utworzenia issue i nazwy brancha)
+      - `--title "<Tytuł>"` (używane, gdy trzeba utworzyć nowe issue)
+      - `--desc "<Opis>"` (krótki opis do utworzenia issue i nazwy brancha)
+      - `--dirty-strategy <stash|commit-wip|move-to-new-branch|other>` (opcjonalnie; pomija interaktywny wybór)
+      - `--dirty-instruction "<tekst>"` (wymagane dla `other` bez TTY)
      - `--base <remote/branch|branch>` (opcjonalnie; domyślnie domyślna gałąź repo)
    - Nazwa brancha jest wyprowadzana przez wspólny helper `node <skills_root>/_shared/scripts/issue-branch.mjs` i ma postać `issue/<ID>-<slug>`.
-   - Skrypt przed utworzeniem nowego brancha wykonuje `git fetch` dla base ref, aby mieć aktualną bazę.
-   - Skrypt zawsze tworzy lub checkoutuje branch dla wskazanego issue (jeśli branch nie istnieje, zostanie utworzony).
+    - Skrypt przed utworzeniem nowego brancha wykonuje `git fetch` dla base ref, aby mieć aktualną bazę.
+    - Skrypt zawsze tworzy lub checkoutuje branch dla wskazanego issue (jeśli branch nie istnieje, zostanie utworzony).
+    - Każdy checkout jest sprawdzany przez helper `<skills_root>/_shared/scripts/worktree.mjs`; sukces jest raportowany dopiero po potwierdzeniu aktywnego brancha.
+    - Przed checkoutem skrypt sprawdza `git status --porcelain=v1 -uall`. Przy dirty tree, w terminalu interaktywnym pokazuje wybór strzałkami: `stash`, `commit-wip`, `move-to-new-branch` albo `other`.
+    - `stash` zachowuje zmiany w stashu i tworzy czysty branch z bazy; `commit-wip` tworzy jawnie wybrany commit WIP na bieżącym branchu; `move-to-new-branch` aplikuje zmiany na nowym branchu; `other` przekazuje instrukcję agentowi.
+    - Bez TTY i bez `--dirty-strategy` skrypt kończy się błędem zamiast podejmować decyzję za użytkownika. Skrypt nie wykonuje automatycznie stashowania ani commita.
 3. Po powodzeniu skryptu uruchom **osobno** `$gh-issue-status-set`, aby ustawić status **In progress**:
    - Preferuj przekazanie numeru issue:
      - jeśli użyto `--issue-number`, przekaż ten numer,
@@ -75,6 +82,11 @@ Jeśli użytkownik podał `--issue-number`, a issue nie istnieje lub jest zamkni
 - `21` wiele pasujących issue → poproś użytkownika o numer i uruchom ponownie z `--issue-number`.
 - `12` brak base ref (`origin/<default>` albo wartość z `--base`) → sprawdź zdalne branche lub wskaż poprawne `--base`.
 - Inne błędy → odczytaj komunikat skryptu i popraw dane wejściowe.
+
+## Dodatkowe kody wyjścia dirty tree
+- `14` dirty tree bez jawnej strategii albo brak instrukcji dla `other` → wybierz strategię interaktywnie lub podaj parametr.
+- `15` nieudany checkout, stash, commit WIP albo brak potwierdzenia aktywnego brancha → skrypt raportuje komendę i błąd.
+- `16` wybrano `other` → agent otrzymuje instrukcję użytkownika bez automatycznej operacji.
 
 ## Format odpowiedzi
 - Wynik: issue + branch utworzone/przełączone, status ustawiony.

--- a/.agents/skills/gh-issue-start/scripts/start.mjs
+++ b/.agents/skills/gh-issue-start/scripts/start.mjs
@@ -3,6 +3,14 @@ import {spawnSync} from "node:child_process";
 import {fileURLToPath, pathToFileURL} from "node:url";
 
 import {makeIssueBranch} from "../../_shared/scripts/issue-branch.mjs";
+import {
+    applyDirtyTreeStrategy,
+    checkoutBranch,
+    getDirtyTreeStatus,
+    normalizeDirtyTreeStrategy,
+    promptDirtyTreeStrategy,
+    run,
+} from "../../_shared/scripts/worktree.mjs";
 
 const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
 
@@ -13,15 +21,6 @@ export function createExecutor({cwd = repoRoot} = {}) {
         shell: false,
         ...options,
     });
-}
-
-function run(command, args, execCommand) {
-    const result = execCommand(command, args);
-    return {
-        code: result.status ?? 1,
-        stderr: String(result.stderr ?? ""),
-        stdout: String(result.stdout ?? ""),
-    };
 }
 
 export function extractSubjectKeywords(subject) {
@@ -42,6 +41,8 @@ export function parseArgs(argv) {
     const parsed = {
         baseRef: "",
         description: "",
+        dirtyInstruction: "",
+        dirtyStrategy: "",
         issueNumber: "",
         owner: "",
         repo: "",
@@ -59,6 +60,12 @@ export function parseArgs(argv) {
                 break;
             case "--desc":
                 parsed.description = args.shift() ?? "";
+                break;
+            case "--dirty-strategy":
+                parsed.dirtyStrategy = args.shift() ?? "";
+                break;
+            case "--dirty-instruction":
+                parsed.dirtyInstruction = args.shift() ?? "";
                 break;
             case "--owner":
                 parsed.owner = args.shift() ?? "";
@@ -100,7 +107,7 @@ function searchIssueByTitle({execCommand, keywords, owner, repo}) {
         "--json",
         "number,title",
         "-q",
-        '.[] | "\(.number)\t\(.title)"',
+        String.raw`.[] | "\(.number)\t\(.title)"`,
     ], execCommand);
 
     const result = search.stdout.trim();
@@ -122,22 +129,85 @@ function searchIssueByTitle({execCommand, keywords, owner, repo}) {
     };
 }
 
+function prepareWorktree({baseRef, branchName, dirtyInstruction, dirtyStrategy, execCommand, issueNumber, remote}) {
+    const dirtyStatus = getDirtyTreeStatus(execCommand);
+    if (dirtyStatus.code !== 0) {
+        return dirtyStatus;
+    }
+
+    if (!dirtyStatus.dirty) {
+        return checkoutBranch({baseRef, branchName, execCommand, remote});
+    }
+
+    if (dirtyStrategy === "other") {
+        return dirtyInstruction
+            ? {code: 16, stdout: `Instrukcja użytkownika dla agenta: ${dirtyInstruction}\n`}
+            : {code: 14, stderr: "Strategia 'other' wymaga --dirty-instruction albo wyboru interaktywnego."};
+    }
+
+    const selection = dirtyStrategy
+        ? {code: 0, strategy: dirtyStrategy}
+        : promptDirtyTreeStrategy();
+    if (selection.code !== 0) {
+        return selection.code === 16
+            ? {code: 16, stdout: `Instrukcja użytkownika dla agenta: ${selection.instruction}\n`}
+            : selection;
+    }
+
+    return applyDirtyTreeStrategy({
+        baseRef,
+        branchName,
+        execCommand,
+        issueNumber,
+        remote,
+        strategy: selection.strategy,
+    });
+}
+
+function assignCurrentUser({execCommand, issueNumber}) {
+    const currentUserResult = run("gh", ["api", "user", "-q", ".login"], execCommand);
+    if (currentUserResult.code !== 0 || !currentUserResult.stdout.trim()) {
+        return {code: currentUserResult.code || 15, stderr: currentUserResult.stderr || "Nie udało się ustalić bieżącego użytkownika GitHub."};
+    }
+
+    const currentUser = currentUserResult.stdout.trim();
+    const assigneesResult = run("gh", ["issue", "view", issueNumber, "--json", "assignees", "-q", ".assignees[].login"], execCommand);
+    if (assigneesResult.code !== 0) {
+        return {code: assigneesResult.code, stderr: assigneesResult.stderr || "Nie udało się odczytać assignee issue."};
+    }
+
+    const assignees = assigneesResult.stdout.trim().split(/\r?\n/).filter(Boolean);
+    if (assignees.includes(currentUser)) {
+        return {code: 0};
+    }
+
+    const assign = run("gh", ["issue", "edit", issueNumber, "--add-assignee", currentUser], execCommand);
+    return assign.code === 0
+        ? {code: 0}
+        : {code: assign.code, stderr: assign.stderr || "Nie udało się przypisać bieżącego użytkownika do issue."};
+}
+
 export function runIssueStart(argv, {execCommand = createExecutor()} = {}) {
     const parsed = parseArgs(argv);
     if (parsed.error) {
-        return {code: 2, stderr: `${parsed.error}\nUsage: issue-start.mjs [--issue-number <number>] [--title <title>] [--desc <description>] [--owner <owner>] [--repo <repo>] [--base <ref>]\n`};
+        return {code: 2, stderr: `${parsed.error}\nUsage: issue-start.mjs [--issue-number <number>] [--title <title>] [--desc <description>] [--dirty-strategy <stash|commit-wip|move-to-new-branch|other>] [--dirty-instruction <tekst>] [--owner <owner>] [--repo <repo>] [--base <ref>]\n`};
     }
     if (parsed.help) {
-        return {code: 0, stdout: "Usage: issue-start.mjs [--issue-number <number>] [--title <title>] [--desc <description>] [--owner <owner>] [--repo <repo>] [--base <ref>]\n"};
+        return {code: 0, stdout: "Usage: issue-start.mjs [--issue-number <number>] [--title <title>] [--desc <description>] [--dirty-strategy <stash|commit-wip|move-to-new-branch|other>] [--dirty-instruction <tekst>] [--owner <owner>] [--repo <repo>] [--base <ref>]\n"};
     }
 
     let {baseRef, issueNumber, owner, repo, title} = parsed;
     const {description} = parsed;
+    const {dirtyInstruction, dirtyStrategy} = parsed;
+
+    if (dirtyStrategy && !normalizeDirtyTreeStrategy(dirtyStrategy)) {
+        return {code: 2, stderr: `Nieznana strategia dirty tree: ${dirtyStrategy}. Użyj stash, commit-wip, move-to-new-branch, other albo pomiń parametr dla wyboru strzałkami.\n`};
+    }
 
     if (!owner || !repo) {
         const repoView = run("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], execCommand);
-        if (repoView.code !== 0) {
-            return {code: repoView.code, stderr: repoView.stderr};
+        if (repoView.code !== 0 || !repoView.stdout.trim()) {
+            return {code: repoView.code || 7, stderr: repoView.stderr || "Nie udało się ustalić repozytorium GitHub."};
         }
         const repoFull = repoView.stdout.trim();
         [owner, repo] = repoFull.split("/");
@@ -145,7 +215,10 @@ export function runIssueStart(argv, {execCommand = createExecutor()} = {}) {
 
     if (!baseRef) {
         const defaultBranch = run("gh", ["repo", "view", `${owner}/${repo}`, "--json", "defaultBranchRef", "-q", ".defaultBranchRef.name"], execCommand);
-        baseRef = defaultBranch.code === 0 && defaultBranch.stdout.trim() ? `origin/${defaultBranch.stdout.trim()}` : "origin/main";
+        if (defaultBranch.code !== 0 || !defaultBranch.stdout.trim()) {
+            return {code: defaultBranch.code || 12, stderr: defaultBranch.stderr || "Nie udało się ustalić domyślnej gałęzi repozytorium."};
+        }
+        baseRef = `origin/${defaultBranch.stdout.trim()}`;
     }
 
     if (!issueNumber && (description || title)) {
@@ -210,23 +283,19 @@ export function runIssueStart(argv, {execCommand = createExecutor()} = {}) {
         return {code: result.code, stderr: result.stderr};
     }
 
-    result = run("git", ["show-ref", "--verify", "--quiet", `refs/remotes/${baseRef}`], execCommand);
+    result = run("git", ["show-ref", "--verify", "--quiet", `refs/remotes/${remote}/${baseBranch}`], execCommand);
     if (result.code !== 0) {
         return {code: 12, stderr: `Missing base ref ${baseRef}.\n`};
     }
 
-    if (run("git", ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`], execCommand).code === 0) {
-        run("git", ["checkout", branchName], execCommand);
-    } else if (run("git", ["show-ref", "--verify", "--quiet", `refs/remotes/origin/${branchName}`], execCommand).code === 0) {
-        run("git", ["checkout", "-b", branchName, "--track", `origin/${branchName}`], execCommand);
-    } else {
-        run("git", ["checkout", "-b", branchName, baseRef], execCommand);
+    const worktree = prepareWorktree({baseRef, branchName, dirtyInstruction, dirtyStrategy, execCommand, issueNumber, remote});
+    if (worktree.code !== 0) {
+        return worktree;
     }
 
-    const currentUser = run("gh", ["api", "user", "-q", ".login"], execCommand).stdout.trim();
-    const assignees = run("gh", ["issue", "view", issueNumber, "--json", "assignees", "-q", ".assignees[].login"], execCommand).stdout.trim().split(/\r?\n/).filter(Boolean);
-    if (!assignees.includes(currentUser)) {
-        run("gh", ["issue", "edit", issueNumber, "--add-assignee", currentUser], execCommand);
+    const assignment = assignCurrentUser({execCommand, issueNumber});
+    if (assignment.code !== 0) {
+        return assignment;
     }
 
     return {code: 0, stdout: `Issue #${issueNumber} ready on branch ${branchName}.\n`};

--- a/.agents/skills/gh-issue-status-set/SKILL.md
+++ b/.agents/skills/gh-issue-status-set/SKILL.md
@@ -32,14 +32,14 @@ Ustawić status issue w GitHub Projects v2 na podstawie bieżącego brancha, num
 3. Uruchom skrypt:
    - `<skill_dir>/scripts/set-status.mjs --status "<STATUS>"`
    - Opcjonalnie: `--issue <ID>`, `--project-number <NUM>`, `--field <NAZWA>`
-4. Jeśli skrypt zwraca błąd, zinterpretuj kod wyjścia i **zawsze** uruchom skrypt ponownie z uzupełnionymi danymi (bez ręcznego “rzeźbienia”).
+4. Jeśli skrypt zwraca błąd, zinterpretuj kod wyjścia i **zawsze** uruchom skrypt ponownie z uzupełnionymi danymi (bez ręcznego “rzeźbienia”). Skrypt rozpoznaje lokalne aliasy statusów, np. `In progress` → `W trakcie`, `Ready` → `Do wzięcia`, `Done` → `Ukończone`.
 
 ## Interpretacja kodów wyjścia i retry
 - `3` brak numeru issue: spróbuj ustalić issue przez MCP (`mcp__github__search_issues` w repo, użyj słów z ostatniego subject). Jeśli 1 wynik → uruchom skrypt z `--issue`. Jeśli wiele/brak → dopytaj użytkownika.
 - `4` issue nie jest w projekcie i brak `--project-number`: ustal projekt (MCP nie obsługuje Projects v2). Użyj `gh project list --owner <OWNER>` i jeśli jest jedna pozycja → wybierz ją, w przeciwnym razie dopytaj. Następnie uruchom skrypt z `--project-number`.
 - `5` issue jest w wielu projektach: poproś użytkownika o numer projektu i uruchom skrypt z `--project-number`.
 - `6` issue nie jest w wybranym projekcie i nie udało się dodać: dopytaj o właściwy numer projektu albo upewnij się, że issue istnieje w repo, po czym uruchom skrypt ponownie.
-- `7` brak pola/opcji statusu: sprawdź pola `gh project field-list <OWNER>/<PROJECT_NUMBER>` i uruchom skrypt z `--field <NAZWA>` oraz poprawnym `--status`, jeśli potrzeba. Gdy nadal niejasne → dopytaj użytkownika.
+- `7` brak pola/opcji statusu albo nieprawidłowy numer projektu: sprawdź pola `gh project field-list <PROJECT_NUMBER> --owner <OWNER>` i uruchom skrypt z `--field <NAZWA>` oraz poprawnym `--status`, jeśli potrzeba. Gdy nadal niejasne → dopytaj użytkownika.
 - `8` brak statusu: ustal oczekiwany status z kontekstu rozmowy albo dopytaj użytkownika i uruchom skrypt z `--status`.
 
 ## Dobór statusu (proste mapowanie)

--- a/.agents/skills/gh-issue-status-set/scripts/set-status.mjs
+++ b/.agents/skills/gh-issue-status-set/scripts/set-status.mjs
@@ -87,6 +87,33 @@ function extractSubjectKeywords(subject) {
         .join(" ");
 }
 
+const STATUS_ALIASES = new Map([
+    ["in progress", ["W trakcie"]],
+    ["ready", ["Do wzięcia"]],
+    ["done", ["Ukończone"]],
+]);
+
+function normalizeStatus(status) {
+    return String(status ?? "").normalize("NFKD").replace(/\p{Diacritic}/gu, "").toLowerCase().trim();
+}
+
+export function statusCandidates(status) {
+    const requested = String(status ?? "").trim();
+    return [...new Set([requested, ...(STATUS_ALIASES.get(normalizeStatus(requested)) ?? [])].filter(Boolean))];
+}
+
+function escapeJqString(value) {
+    return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function statusOptionPredicate(status) {
+    return statusCandidates(status).map((candidate) => `.name=="${escapeJqString(candidate)}"`).join(" or ");
+}
+
+function isProjectNumber(value) {
+    return /^\d+$/.test(String(value ?? ""));
+}
+
 function searchIssueByTitle({execCommand, keywords, owner, repo}) {
     if (!keywords) {
         return "";
@@ -99,7 +126,7 @@ function searchIssueByTitle({execCommand, keywords, owner, repo}) {
         "--json",
         "number,title",
         "-q",
-        '.[] | "\(.number)\t\(.title)"',
+        String.raw`.[] | "\(.number)\t\(.title)"`,
     ], execCommand);
 
     const result = search.stdout.trim();
@@ -134,10 +161,10 @@ function setFieldValueById({execCommand, fieldName, itemId, owner, projectNumber
     }
 
     const escapedFieldName = fieldName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    const escapedStatus = status.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const optionPredicate = statusOptionPredicate(status);
 
     const fieldQuery = `((.data.organization.projectV2.fields.nodes // .data.user.projectV2.fields.nodes // []) | map(select(.name=="${escapedFieldName}")) | .[0].id) // empty`;
-    const optionQuery = `((.data.organization.projectV2.fields.nodes // .data.user.projectV2.fields.nodes // []) | map(select(.name=="${escapedFieldName}")) | .[0].options // [] | map(select(.name=="${escapedStatus}")) | .[0].id) // empty`;
+    const optionQuery = `((.data.organization.projectV2.fields.nodes // .data.user.projectV2.fields.nodes // []) | map(select(.name=="${escapedFieldName}")) | .[0].options // [] | map(select(${optionPredicate})) | .[0].id) // empty`;
 
     const fieldId = run("gh", ["api", "graphql", "-F", "owner=" + owner, "-F", "number=" + projectNumber, "-f", `query=${projectQuery}`, "--jq", fieldQuery], execCommand).stdout.trim();
     const optionId = run("gh", ["api", "graphql", "-F", "owner=" + owner, "-F", "number=" + projectNumber, "-f", `query=${projectQuery}`, "--jq", optionQuery], execCommand).stdout.trim();
@@ -160,6 +187,53 @@ function setFieldValueById({execCommand, fieldName, itemId, owner, projectNumber
     return {code: 0};
 }
 
+function resolveProjectItem({execCommand, issueNumber, owner, projectNumber, repo}) {
+    if (projectNumber && !isProjectNumber(projectNumber)) {
+        return {code: 7, stderr: `Nieprawidłowy numer projektu '${projectNumber}'. Podaj numeryczny --project-number.\n`};
+    }
+
+    const itemsResult = run("gh", ["api", "graphql", "-F", "owner=" + owner, "-F", "repo=" + repo, "-F", "number=" + issueNumber, "-f", "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { issue(number:$number) { projectItems(first: 20) { nodes { id project { id title number } } } } } }", "--jq", String.raw`.data.repository.issue.projectItems.nodes[] | "\(.id)\t\(.project.title)\t\(.project.number)"`], execCommand);
+    if (itemsResult.code !== 0) {
+        return {code: itemsResult.code || 7, stderr: itemsResult.stderr || "Nie udało się odczytać projektów przypisanych do issue."};
+    }
+
+    const itemsRaw = itemsResult.stdout.trim();
+    const addItemToProject = (project) => run("gh", ["project", "item-add", project, "--owner", owner, "--url", `https://github.com/${owner}/${repo}/issues/${issueNumber}`, "--format", "json", "-q", ".id"], execCommand);
+    if (!itemsRaw && !projectNumber) {
+        return {code: 4, stderr: `Issue #${issueNumber} nie jest w żadnym ProjectV2. Podaj --project-number, aby je dodać.\n`};
+    }
+
+    if (!itemsRaw) {
+        const addedItem = addItemToProject(projectNumber);
+        return addedItem.code === 0 && addedItem.stdout.trim()
+            ? {code: 0, itemId: addedItem.stdout.trim(), projectNumber}
+            : {code: 6, stderr: addedItem.stderr || `Nie udało się dodać issue #${issueNumber} do projektu o numerze ${projectNumber}.\n`};
+    }
+
+    const items = itemsRaw.split(/\r?\n/).filter(Boolean);
+    if (!projectNumber && items.length > 1) {
+        return {code: 5, stderr: `Issue #${issueNumber} znajduje się w wielu projektach:\n${items.map((line) => {
+            const [, title, number] = line.split("\t");
+            return `- ${title} (numer ${number}) element=${line.split("\t")[0]}`;
+        }).join("\n")}\nPodaj --project-number, aby wybrać.\n`};
+    }
+
+    const selectedProjectNumber = projectNumber || items[0].split("\t")[2] || "";
+    if (!isProjectNumber(selectedProjectNumber)) {
+        return {code: 7, stderr: `Nieprawidłowy numer projektu '${selectedProjectNumber}'. Podaj numeryczny --project-number.\n`};
+    }
+
+    const selectedItem = items.find((line) => line.split("\t")[2] === selectedProjectNumber)?.split("\t")[0] ?? "";
+    if (selectedItem) {
+        return {code: 0, itemId: selectedItem, projectNumber: selectedProjectNumber};
+    }
+
+    const addedItem = addItemToProject(selectedProjectNumber);
+    return addedItem.code === 0 && addedItem.stdout.trim()
+        ? {code: 0, itemId: addedItem.stdout.trim(), projectNumber: selectedProjectNumber}
+        : {code: 6, stderr: addedItem.stderr || `Issue #${issueNumber} nie należy do projektu o numerze ${selectedProjectNumber} i nie udało się go dodać.\n`};
+}
+
 export function runIssueStatusSet(argv, {execCommand = createExecutor()} = {}) {
     const parsed = parseArgs(argv);
     if (parsed.error) {
@@ -175,7 +249,11 @@ export function runIssueStatusSet(argv, {execCommand = createExecutor()} = {}) {
     let {issueNumber, owner, projectNumber, repo} = parsed;
     const {fieldName, status} = parsed;
     if (!owner || !repo) {
-        const repoFull = run("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], execCommand).stdout.trim();
+        const repoView = run("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], execCommand);
+        if (repoView.code !== 0 || !repoView.stdout.trim()) {
+            return {code: repoView.code || 7, stderr: repoView.stderr || "Nie udało się ustalić repozytorium GitHub."};
+        }
+        const repoFull = repoView.stdout.trim();
         [owner, repo] = repoFull.split("/");
     }
 
@@ -200,41 +278,12 @@ export function runIssueStatusSet(argv, {execCommand = createExecutor()} = {}) {
     if (!issueNumber) {
         return {code: 3, stderr: "Nie można ustalić numeru issue. Podaj --issue lub użyj nazwy brancha issue/<ID>-*.\n"};
     }
-
-    const itemsRaw = run("gh", ["api", "graphql", "-F", "owner=" + owner, "-F", "repo=" + repo, "-F", "number=" + issueNumber, "-f", "query=query($owner:String!, $repo:String!, $number:Int!) { repository(owner:$owner, name:$repo) { issue(number:$number) { projectItems(first: 20) { nodes { id project { id title number } } } } } }", "--jq", '.data.repository.issue.projectItems.nodes[] | "\(.id)\t\(.project.title)\t\(.project.number)"'], execCommand).stdout.trim();
-
-    const addItemToProject = (projNum) => run("gh", ["project", "item-add", projNum, "--owner", owner, "--url", `https://github.com/${owner}/${repo}/issues/${issueNumber}`, "--format", "json", "-q", ".id"], execCommand).stdout.trim();
-
-    let itemId;
-    if (!itemsRaw) {
-        if (!projectNumber) {
-            return {code: 4, stderr: `Issue #${issueNumber} nie jest w żadnym ProjectV2. Podaj --project-number, aby je dodać.\n`};
-        }
-
-        itemId = addItemToProject(projectNumber);
-        if (!itemId) {
-            return {code: 6, stderr: `Nie udało się dodać issue #${issueNumber} do projektu o numerze ${projectNumber}.\n`};
-        }
-    } else {
-        const items = itemsRaw.split(/\r?\n/).filter(Boolean);
-        if (!projectNumber) {
-            if (items.length > 1) {
-                return {code: 5, stderr: `Issue #${issueNumber} znajduje się w wielu projektach:\n${items.map((line) => {
-                    const [, title, number] = line.split("\t");
-                    return `- ${title} (numer ${number}) element=${line.split("\t")[0]}`;
-                }).join("\n")}\nPodaj --project-number, aby wybrać.\n`};
-            }
-            projectNumber = items[0].split("\t")[2] ?? "";
-        }
-
-        itemId = items.find((line) => line.split("\t")[2] === projectNumber)?.split("\t")[0] ?? "";
-        if (!itemId) {
-            itemId = addItemToProject(projectNumber);
-            if (!itemId) {
-                return {code: 6, stderr: `Issue #${issueNumber} nie należy do projektu o numerze ${projectNumber} i nie udało się go dodać.\n`};
-            }
-        }
+    const projectItem = resolveProjectItem({execCommand, issueNumber, owner, projectNumber, repo});
+    if (projectItem.code !== 0) {
+        return projectItem;
     }
+    const {itemId} = projectItem;
+    projectNumber = projectItem.projectNumber;
 
     const projectRef = `${owner}/${projectNumber}`;
     const itemEditHelp = run("gh", ["project", "item-edit", "--help"], execCommand).stdout;
@@ -254,7 +303,18 @@ export function runIssueStatusSet(argv, {execCommand = createExecutor()} = {}) {
             return outcome;
         }
     } else {
-        const edit = run("gh", ["project", "item-edit", "--project", projectRef, "--id", itemId, "--field", fieldName, "--single-select-option", status], execCommand);
+        const fields = run("gh", ["project", "field-list", projectNumber, "--owner", owner, "--format", "json"], execCommand);
+        let selectedStatus = status;
+        if (fields.code === 0) {
+            try {
+                const field = JSON.parse(fields.stdout).fields?.find((candidate) => candidate.name === fieldName);
+                const availableStatuses = field?.options?.map((option) => option.name) ?? [];
+                selectedStatus = statusCandidates(status).find((candidate) => availableStatuses.includes(candidate)) ?? status;
+            } catch {
+                selectedStatus = status;
+            }
+        }
+        const edit = run("gh", ["project", "item-edit", "--project", projectRef, "--id", itemId, "--field", fieldName, "--single-select-option", selectedStatus], execCommand);
         if (edit.code !== 0) {
             return {code: 7, stderr: `Nie udało się ustawić statusu '${status}' używając pola '${fieldName}' w projekcie ${projectRef}.\nSprawdź pola: gh project field-list ${projectRef}\n`};
         }

--- a/tests/skills/_shared/worktree.test.mjs
+++ b/tests/skills/_shared/worktree.test.mjs
@@ -1,0 +1,94 @@
+import {describe, expect, it} from "vitest";
+
+import {
+    applyDirtyTreeStrategy,
+    DIRTY_TREE_STRATEGIES,
+    normalizeDirtyTreeStrategy,
+    promptDirtyTreeStrategy,
+} from "../../../.agents/skills/_shared/scripts/worktree.mjs";
+
+describe("worktree helpers", () => {
+    it("normalizes only supported dirty tree strategies", () => {
+        expect(normalizeDirtyTreeStrategy("move-to-new-branch")).toBe("move-to-new-branch");
+        expect(normalizeDirtyTreeStrategy("unknown")).toBe("");
+    });
+
+    it("supports arrow-key selection in an interactive terminal", () => {
+        const inputBytes = [0x1b, 0x5b, 0x42, 0x0d];
+        const output = {isTTY: true, write: (...args) => args.length};
+        const input = {
+            fd: 0,
+            isRaw: false,
+            isTTY: true,
+            resume: (...args) => args.length,
+            setRawMode: (...args) => args.length,
+        };
+        const read = (_fd, buffer, offset) => {
+            buffer[offset] = inputBytes.shift();
+            return 1;
+        };
+
+        const result = promptDirtyTreeStrategy({input, output, read});
+
+        expect(DIRTY_TREE_STRATEGIES).toHaveLength(4);
+        expect(result).toEqual({code: 0, strategy: "commit-wip"});
+    });
+
+    it("requires an explicit strategy outside a TTY", () => {
+        const result = promptDirtyTreeStrategy({
+            input: {isTTY: false},
+            output: {isTTY: false},
+        });
+
+        expect(result.code).toBe(14);
+        expect(result.stderr).toContain("--dirty-strategy");
+    });
+
+    it("commits WIP changes before switching to the issue branch", () => {
+        const calls = [];
+        const execCommand = (command, args) => {
+            calls.push([command, ...args].join(" "));
+            if (command === "git" && args[0] === "show-ref") { return {status: 1, stdout: "", stderr: ""}; }
+            if (command === "git" && args[0] === "checkout") { return {status: 0, stdout: "", stderr: ""}; }
+            if (command === "git" && args[0] === "branch") { return {status: 0, stdout: "issue/12-target\n", stderr: ""}; }
+            return {status: 0, stdout: "", stderr: ""};
+        };
+
+        const result = applyDirtyTreeStrategy({
+            baseRef: "origin/main",
+            branchName: "issue/12-target",
+            execCommand,
+            issueNumber: "12",
+            remote: "origin",
+            strategy: "commit-wip",
+        });
+
+        expect(result.code).toBe(0);
+        expect(calls).toContain("git add -A");
+        expect(calls).toContain("git commit -m wip: preserve changes before issue #12");
+    });
+
+    it("applies and drops the temporary stash when moving changes", () => {
+        const calls = [];
+        const execCommand = (command, args) => {
+            calls.push([command, ...args].join(" "));
+            if (command === "git" && args[0] === "show-ref") { return {status: 1, stdout: "", stderr: ""}; }
+            if (command === "git" && args[0] === "checkout") { return {status: 0, stdout: "", stderr: ""}; }
+            if (command === "git" && args[0] === "branch") { return {status: 0, stdout: "issue/12-target\n", stderr: ""}; }
+            return {status: 0, stdout: "", stderr: ""};
+        };
+
+        const result = applyDirtyTreeStrategy({
+            baseRef: "origin/main",
+            branchName: "issue/12-target",
+            execCommand,
+            issueNumber: "12",
+            remote: "origin",
+            strategy: "move-to-new-branch",
+        });
+
+        expect(result.code).toBe(0);
+        expect(calls).toContain("git stash apply");
+        expect(calls).toContain("git stash drop");
+    });
+});

--- a/tests/skills/gh-issue-start/start.test.mjs
+++ b/tests/skills/gh-issue-start/start.test.mjs
@@ -35,6 +35,9 @@ describe("gh-issue-start", () => {
             if (command === "git" && args[0] === "fetch") {
                 return {status: 0, stdout: "", stderr: ""};
             }
+            if (command === "git" && args[0] === "status") {
+                return {status: 0, stdout: "", stderr: ""};
+            }
             if (command === "git" && args[0] === "show-ref") {
                 if (args[3] === "refs/remotes/origin/main") {
                     return {status: 0, stdout: "", stderr: ""};
@@ -43,6 +46,9 @@ describe("gh-issue-start", () => {
             }
             if (command === "git" && args[0] === "checkout") {
                 return {status: 0, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "branch" && args[1] === "--show-current") {
+                return {status: 0, stdout: "issue/77-feat-add-support\n", stderr: ""};
             }
 
             throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
@@ -58,6 +64,92 @@ describe("gh-issue-start", () => {
         expect(calls).toContain("gh issue create --repo acme/demo --title feat: add support --body ");
         expect(calls).toContain("git checkout -b issue/77-feat-add-support origin/main");
         expect(calls).toContain("gh issue edit 77 --add-assignee codex");
+    });
+
+    it("reports checkout failure instead of claiming success", () => {
+        const execCommand = (command, args) => {
+            if (command === "gh" && args[0] === "repo" && args[1] === "view" && args.includes("nameWithOwner")) {
+                return {status: 0, stdout: "acme/demo\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "repo" && args[1] === "view" && args.includes("defaultBranchRef")) {
+                return {status: 0, stdout: "main\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "issue" && args[1] === "view" && args.includes(".state + \"\t\" + .title")) {
+                return {status: 0, stdout: "OPEN\tAdd support\n", stderr: ""};
+            }
+            if (command === "git" && args[0] === "fetch") {
+                return {status: 0, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "show-ref") {
+                if (args[3] === "refs/remotes/origin/main") {
+                    return {status: 0, stdout: "", stderr: ""};
+                }
+                return {status: 1, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "status") {
+                return {status: 0, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "checkout") {
+                return {status: 1, stdout: "", stderr: "would overwrite local changes"};
+            }
+
+            throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+        };
+
+        const result = runIssueStart(["--issue-number", "77"], {execCommand});
+
+        expect(result.code).toBe(15);
+        expect(result.stderr).toContain("would overwrite local changes");
+    });
+
+    it("uses an explicit stash strategy for a dirty tree", () => {
+        const calls = [];
+        const execCommand = (command, args) => {
+            calls.push([command, ...args].join(" "));
+            if (command === "gh" && args[0] === "repo" && args[1] === "view" && args.includes("nameWithOwner")) {
+                return {status: 0, stdout: "acme/demo\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "repo" && args[1] === "view" && args.includes("defaultBranchRef")) {
+                return {status: 0, stdout: "main\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "issue" && args[1] === "view" && args.includes(".state + \"\t\" + .title")) {
+                return {status: 0, stdout: "OPEN\tAdd support\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "api" && args[1] === "user") {
+                return {status: 0, stdout: "codex\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "issue" && args[1] === "view" && args.includes(".assignees[].login")) {
+                return {status: 0, stdout: "codex\n", stderr: ""};
+            }
+            if (command === "git" && args[0] === "fetch") {
+                return {status: 0, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "show-ref") {
+                if (args[3] === "refs/remotes/origin/main") {
+                    return {status: 0, stdout: "", stderr: ""};
+                }
+                return {status: 1, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "status") {
+                return {status: 0, stdout: " M file.txt\n", stderr: ""};
+            }
+            if (command === "git" && args[0] === "stash") {
+                return {status: 0, stdout: "Saved working directory state\n", stderr: ""};
+            }
+            if (command === "git" && args[0] === "checkout") {
+                return {status: 0, stdout: "", stderr: ""};
+            }
+            if (command === "git" && args[0] === "branch" && args[1] === "--show-current") {
+                return {status: 0, stdout: "issue/77-add-support\n", stderr: ""};
+            }
+
+            throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+        };
+
+        const result = runIssueStart(["--issue-number", "77", "--dirty-strategy", "stash"], {execCommand});
+
+        expect(result.code).toBe(0);
+        expect(calls).toContain("git stash push --include-untracked -m wip: preserve changes before issue #77");
     });
 
     it("rejects ambiguous search results", () => {

--- a/tests/skills/gh-issue-status-set/set-status.test.mjs
+++ b/tests/skills/gh-issue-status-set/set-status.test.mjs
@@ -20,6 +20,9 @@ describe("gh-issue-status-set", () => {
             if (command === "gh" && args[0] === "project" && args[1] === "item-edit" && args[2] === "--help") {
                 return {status: 0, stdout: "Usage: gh project item-edit\n", stderr: ""};
             }
+            if (command === "gh" && args[0] === "project" && args[1] === "field-list") {
+                return {status: 0, stdout: JSON.stringify({fields: [{name: "Status", options: [{name: "In review"}]}]}), stderr: ""};
+            }
             if (command === "gh" && args[0] === "project" && args[1] === "item-edit") {
                 return {status: 0, stdout: "", stderr: ""};
             }
@@ -33,7 +36,40 @@ describe("gh-issue-status-set", () => {
             code: 0,
             stdout: "Status 'In review' ustawiony dla issue #123 w projekcie acme/7 (element item-1).\n",
         });
+        expect(calls.some((call) => call.includes("\\(.project.number)"))).toBe(true);
         expect(calls).toContain("gh project item-edit --project acme/7 --id item-1 --field Status --single-select-option In review");
+    });
+
+    it("maps semantic status names to a localized project option", () => {
+        const calls = [];
+        const execCommand = (command, args) => {
+            calls.push([command, ...args].join(" "));
+            if (command === "gh" && args[0] === "repo" && args[1] === "view") {
+                return {status: 0, stdout: "acme/demo\n", stderr: ""};
+            }
+            if (command === "git" && args[0] === "rev-parse") {
+                return {status: 0, stdout: "issue/123-demo\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "api" && args[1] === "graphql" && args.some((arg) => String(arg).includes("projectItems"))) {
+                return {status: 0, stdout: "item-1\tProject Alpha\t7\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "project" && args[1] === "item-edit" && args[2] === "--help") {
+                return {status: 0, stdout: "Usage: gh project item-edit\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "project" && args[1] === "field-list") {
+                return {status: 0, stdout: JSON.stringify({fields: [{name: "Status", options: [{name: "W trakcie"}]}]}), stderr: ""};
+            }
+            if (command === "gh" && args[0] === "project" && args[1] === "item-edit") {
+                return {status: 0, stdout: "", stderr: ""};
+            }
+
+            throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+        };
+
+        const result = runIssueStatusSet(["--status", "In progress"], {execCommand});
+
+        expect(result.code).toBe(0);
+        expect(calls).toContain("gh project item-edit --project acme/7 --id item-1 --field Status --single-select-option W trakcie");
     });
 
     it("adds an issue to a project and uses the id-based item editor", () => {
@@ -80,5 +116,26 @@ describe("gh-issue-status-set", () => {
         });
         expect(calls).toContain("gh project item-add 9 --owner acme --url https://github.com/acme/demo/issues/45 --format json -q .id");
         expect(calls).toContain("gh project item-edit --project-id project-1 --id item-9 --field-id field-1 --single-select-option-id option-1");
+    });
+
+    it("rejects malformed project numbers instead of invoking another project", () => {
+        const execCommand = (command, args) => {
+            if (command === "gh" && args[0] === "repo" && args[1] === "view") {
+                return {status: 0, stdout: "acme/demo\n", stderr: ""};
+            }
+            if (command === "git" && args[0] === "rev-parse") {
+                return {status: 0, stdout: "issue/123-demo\n", stderr: ""};
+            }
+            if (command === "gh" && args[0] === "api" && args[1] === "graphql") {
+                return {status: 0, stdout: "item-1\tProject Alpha\t(.project.number)\n", stderr: ""};
+            }
+
+            throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+        };
+
+        const result = runIssueStatusSet(["--status", "In progress"], {execCommand});
+
+        expect(result.code).toBe(7);
+        expect(result.stderr).toContain("Nieprawidłowy numer projektu");
     });
 });


### PR DESCRIPTION
## Zmiany ogólne
- Dodano wspólny helper do wykrywania dirty tree oraz bezpiecznego checkoutu.
- Dodano interaktywne strategie stash, WIP commit, przeniesienie zmian i własną instrukcję.
- Rozszerzono testy regresyjne dla workflow pracy z issue.

## Zmiany API poleceń CLI
- Zwalidowano wyniki operacji Git, przypisania użytkownika i operacji ProjectV2.
- Naprawiono odczyt numeru projektu z jq oraz aliasowanie lokalnych statusów Projects v2.