### PR TITLE
fix(skills): harden issue branches and cross-module SQL reads

### DIFF
--- a/.agents/skills/_shared/references/cqrs-monolith-standard-overrides.md
+++ b/.agents/skills/_shared/references/cqrs-monolith-standard-overrides.md
@@ -248,14 +248,22 @@ Przy dodawaniu nowej klasy przejdź przez poniższe pytania w kolejności:
 - Dozwolone cross-module:
   - zależność do `TargetModule/Application/UseCase/Command/**` oraz `TargetModule/Application/UseCase/Query/**` jako publicznych kontraktów messages w tym profilu,
   - zależność do `TargetModule/Application/Port/In/**` wyłącznie przy implementacji jawnie udokumentowanego kontraktu pluginowego modułu docelowego,
-  - uzgodnione kontrakty współdzielone z `Shared`.
+  - uzgodnione kontrakty współdzielone z `Shared`,
+  - kontrolowany, wyłącznie odczytowy read model SQL (`SELECT`, w tym `JOIN` / `UNION` / CTE) łączący tabele należące do kilku modułów, jeśli wszystkie poniższe warunki są spełnione:
+    - zapytanie działa na jednym połączeniu i w tej samej bazie danych; nie emuluje joinów między połączeniami,
+    - implementacja pozostaje w `Infrastructure/Repository/**` modułu będącego właścicielem przekrojowego use case'a i implementuje jego lokalny port z `Application/Port/Out/**` zakończony sufiksem `ReadRepositoryPort`,
+    - kod PHP nie importuje encji, repozytoriów, portów `Out`, klas `Domain` ani `Infrastructure` obcych modułów; zależność od obcych modułów istnieje wyłącznie na poziomie jawnie nazwanych tabel i kolumn SQL,
+    - zapytanie nie zapisuje, nie naprawia i nie usuwa danych w tabelach obcych modułów,
+    - read model respektuje tenant scope, soft-delete, uprawnienia do każdego źródła, stabilną paginację oraz semantykę danych właściciela tabeli,
+    - zależność od tabel obcych modułów jest jawnie opisana w dokumentacji modułu/read modelu i pokryta testami integracyjnymi wykrywającymi zmianę kontraktu tabel,
+    - wyjątek służy agregacji/reportingowi read-side, a nie obchodzeniu publicznego API modułu dla zwykłego odczytu CRUD.
 - Niedozwolone cross-module:
   - zależność do `TargetModule/Application/Port/In/**` jako alternatywy dla `CommandBus` / `QueryBus` w odczycie i zapisie danych biznesowych,
   - zależność do `TargetModule/Application/Port/Out/**`,
   - zależność do `TargetModule/Application/Port/*.php` (płaskie porty legacy poza wyjątkami technicznymi),
   - zależność do `TargetModule/Domain/**` i `TargetModule/Infrastructure/**` innego modułu.
 - Niedozwolone obejścia:
-  - bezpośredni odczyt tabel, encji Doctrine, repozytoriów lub innych szczegółów persystencji obcego modułu tylko po to, aby ominąć jego application layer,
+  - bezpośredni odczyt encji Doctrine, repozytoriów lub innych szczegółów persystencji obcego modułu; bezpośredni odczyt tabel jest dozwolony wyłącznie w kontrolowanym wyjątku read-side SQL opisanym powyżej,
   - „sprytne” odpowiedniki cross-module API budowane poza `CommandBus` / `QueryBus`.
 
 ## 9. Doctrine i model relacji (override)

--- a/.agents/skills/_shared/scripts/worktree.mjs
+++ b/.agents/skills/_shared/scripts/worktree.mjs
@@ -40,6 +40,63 @@ export function commandFailure(command, args, result) {
     return `Nie udało się wykonać: ${command} ${args.join(" ")} (${details}).`;
 }
 
+function resolveAheadBehind({branchName, baseRef, execCommand}) {
+    const args = ["rev-list", "--left-right", "--count", `${branchName}...${baseRef}`];
+    const result = run("git", args, execCommand);
+    if (result.code !== 0) {
+        return {
+            code: 15,
+            stderr: commandFailure("git", args, result),
+        };
+    }
+
+    const values = result.stdout.trim().split(/\s+/).map(Number);
+    if (values.length !== 2 || values.some((value) => !Number.isInteger(value) || value < 0)) {
+        return {
+            code: 15,
+            stderr: `Nie udało się ustalić rozjazdu brancha '${branchName}' względem bazy '${baseRef}'. Oczekiwano dwóch liczników ahead/behind.`,
+        };
+    }
+
+    return {code: 0, ahead: values[0], behind: values[1]};
+}
+
+export function synchronizeBranchWithBase({branchName, baseRef, execCommand}) {
+    const divergence = resolveAheadBehind({branchName, baseRef, execCommand});
+    if (divergence.code !== 0) {
+        return divergence;
+    }
+
+    const {ahead, behind} = divergence;
+    if (behind === 0) {
+        return {code: 0, ahead, behind, synchronized: true};
+    }
+
+    if (ahead > 0) {
+        return {
+            code: 17,
+            ahead,
+            behind,
+            synchronized: false,
+            stderr: `Branch '${branchName}' jest rozjechany z bazą '${baseRef}' (ahead ${ahead}, behind ${behind}). Automatyczny fast-forward nie jest możliwy; wybierz rebase albo merge świadomie.`,
+        };
+    }
+
+    const args = ["merge", "--ff-only", baseRef];
+    const result = run("git", args, execCommand);
+    if (result.code !== 0) {
+        return {
+            code: 15,
+            ahead,
+            behind,
+            synchronized: false,
+            stderr: commandFailure("git", args, result),
+        };
+    }
+
+    return {code: 0, ahead: 0, behind, synchronized: true, fastForwarded: true};
+}
+
 export function getDirtyTreeStatus(execCommand) {
     const result = run("git", ["status", "--porcelain=v1", "-uall"], execCommand);
 
@@ -172,7 +229,15 @@ export function checkoutBranch({branchName, baseRef, remote, execCommand}) {
         };
     }
 
-    return {code: 0, branchName};
+    const synchronization = synchronizeBranchWithBase({branchName, baseRef, execCommand});
+    if (synchronization.code !== 0) {
+        return {
+            ...synchronization,
+            branchName,
+        };
+    }
+
+    return {code: 0, branchName, ...synchronization};
 }
 
 export function applyDirtyTreeStrategy({strategy, issueNumber, branchName, baseRef, remote, execCommand}) {

--- a/.agents/skills/gh-issue-start/SKILL.md
+++ b/.agents/skills/gh-issue-start/SKILL.md
@@ -39,9 +39,10 @@ Zautomatyzować start pracy nad issue: ustalenie numeru issue, utworzenie/checko
       - `--dirty-instruction "<tekst>"` (wymagane dla `other` bez TTY)
      - `--base <remote/branch|branch>` (opcjonalnie; domyślnie domyślna gałąź repo)
    - Nazwa brancha jest wyprowadzana przez wspólny helper `node <skills_root>/_shared/scripts/issue-branch.mjs` i ma postać `issue/<ID>-<slug>`.
-    - Skrypt przed utworzeniem nowego brancha wykonuje `git fetch` dla base ref, aby mieć aktualną bazę.
+    - Skrypt zawsze wykonuje `git fetch` dla base ref przed utworzeniem lub checkoutem brancha, aby porównanie odbywało się ze świeżą bazą.
     - Skrypt zawsze tworzy lub checkoutuje branch dla wskazanego issue (jeśli branch nie istnieje, zostanie utworzony).
-    - Każdy checkout jest sprawdzany przez helper `<skills_root>/_shared/scripts/worktree.mjs`; sukces jest raportowany dopiero po potwierdzeniu aktywnego brancha.
+    - Po checkoutcie istniejącego brancha helper porównuje `ahead/behind` względem base ref: branch wyłącznie za bazą jest aktualizowany przez `git merge --ff-only <base>`, a branch rozjechany w obu kierunkach zatrzymuje procedurę.
+    - Każdy checkout i ewentualna synchronizacja są sprawdzane przez helper `<skills_root>/_shared/scripts/worktree.mjs`; sukces jest raportowany dopiero po potwierdzeniu aktywnego i zgodnego brancha.
     - Przed checkoutem skrypt sprawdza `git status --porcelain=v1 -uall`. Przy dirty tree, w terminalu interaktywnym pokazuje wybór strzałkami: `stash`, `commit-wip`, `move-to-new-branch` albo `other`.
     - `stash` zachowuje zmiany w stashu i tworzy czysty branch z bazy; `commit-wip` tworzy jawnie wybrany commit WIP na bieżącym branchu; `move-to-new-branch` aplikuje zmiany na nowym branchu; `other` przekazuje instrukcję agentowi.
     - Bez TTY i bez `--dirty-strategy` skrypt kończy się błędem zamiast podejmować decyzję za użytkownika. Skrypt nie wykonuje automatycznie stashowania ani commita.
@@ -81,6 +82,7 @@ Jeśli użytkownik podał `--issue-number`, a issue nie istnieje lub jest zamkni
 - `13` issue o podanym numerze nie istnieje lub jest zamknięte → poinformuj użytkownika i poproś o poprawny `--issue-number` (sprawdź, czy issue nie zostało zamknięte).
 - `21` wiele pasujących issue → poproś użytkownika o numer i uruchom ponownie z `--issue-number`.
 - `12` brak base ref (`origin/<default>` albo wartość z `--base`) → sprawdź zdalne branche lub wskaż poprawne `--base`.
+- `17` branch ma rozbieżną historię względem base (`ahead > 0` i `behind > 0`) → zatrzymaj się i uzgodnij rebase albo merge.
 - Inne błędy → odczytaj komunikat skryptu i popraw dane wejściowe.
 
 ## Dodatkowe kody wyjścia dirty tree


### PR DESCRIPTION
- synchronize existing issue branches with the selected base when fast-forward-only is safe
- stop issue-start on divergent histories
- document the updated gh-issue-start behavior
- allow controlled read-only cross-module SQL read models with explicit architecture, security, and testing constraints