### PR TITLE
fix: uszczelniono kolejność task-plan i format pytań

### DIFF
--- a/.agents/skills/gh-issue-start/SKILL.md
+++ b/.agents/skills/gh-issue-start/SKILL.md
@@ -70,6 +70,24 @@ Zautomatyzować start pracy nad issue: ustalenie numeru issue, utworzenie/checko
   dalszy workflow. Nie wolno uruchamiać task-plan ani tworzyć planu z niepełnych
   danych.
 
+### Następne działanie po sukcesie
+
+Sukces `$gh-issue-start` nie oznacza automatycznego uruchomienia `$task-plan`.
+Agent rozróżnia intencję rozpoczęcia pracy od intencji rozpoczęcia pracy **i**
+przygotowania planu:
+
+- jeśli pierwotne polecenie jednoznacznie obejmuje przygotowanie planu (np.
+  „rozpocznij issue 123 i przygotuj plan realizacji”), po sukcesie `start.mjs`
+  oraz `$gh-issue-status-set` uruchom `$task-plan`;
+- jeśli użytkownik poprosił tylko o start issue, nie uruchamiaj `$task-plan`
+  bez pytania. Pokaż gotową stabilną tożsamość issue i zaproponuj następny
+  krok, np. `$task-plan --source github-issue --issue-number <ID>`;
+- sam tytuł lub opis issue nie jest wystarczającym dowodem intencji planowania.
+
+W przypadku automatycznego przejścia przekaż do `$task-plan` stabilną tożsamość
+z wyniku startu: `owner`, `repo`, `issue_number`, `branch` i `base`. Nie przenoś
+do `start.mjs` pobierania body ani komentarzy issue.
+
 ## Źródła parametrów
 - `--issue-number`: gdy użytkownik poda **numer** issue wprost (np. „start issue 46”, „zaczynamy pracę nad 46”).
 - `--desc`: krótki opis zadania podany przez użytkownika (np. „rozpocznij zadanie: dodać skille start/finish”).
@@ -111,6 +129,8 @@ Jeśli użytkownik podał `--issue-number`, a issue nie istnieje lub jest zamkni
 
 ## Format odpowiedzi
 - Wynik: issue + branch utworzone/przełączone, status ustawiony.
+- Następny krok: `$task-plan` uruchomiony po jednoznacznej intencji planowania
+  albo zaproponowany użytkownikowi, jeśli wykonano tylko start.
 - Uwagi: brakujące dane, konflikty oraz ewentualny błąd ustawienia statusu (jeśli dotyczy).
 
 ## Przykłady wejścia

--- a/.agents/skills/task-plan/SKILL.md
+++ b/.agents/skills/task-plan/SKILL.md
@@ -89,6 +89,41 @@ workflow_actions  — działania dozwolone przez aktywny workflow
 Po finalnej akceptacji główny agent może przekazać jawne żądanie do osobnego,
 standardowego workflow implementacji. Task-plan sam go nie uruchamia.
 
+## Obowiązkowa kolejność workflow
+
+Każdy plan przechodzi przez następujące etapy w tej kolejności:
+
+```text
+source/intake
+  → Plan v1
+  → review krytyczny i findings
+  → rewizja planu oraz kolejne review (maks. 3 iteracje)
+  → auto-uproszczenie
+  → review kontrolny uproszczenia
+  → rozstrzygnięcie blockerów i decyzji zakresowych
+  → decyzje work packages
+  → approved
+  → jawny handoff do implementacji
+```
+
+`validate-plan` potwierdza strukturę i niezmienniki danych, ale nie zastępuje
+review ani nie ustawia `review_complete`. Nie wolno pytać użytkownika o
+`accept`, `revise` albo `exclude` dla work packages, dopóki bramka
+`package_decision_gate` nie ma statusu `open`. Decyzje produktowe i zakresowe
+(np. opt-in/default, format odpowiedzi, model alertów albo zakres pilotażu)
+rozstrzygnij przed decyzjami pakietowymi, ponieważ mogą zmienić zakres pakietów.
+Zapisuj je jako top-level `scope_questions`; każda nierozwiązana pozycja blokuje
+otwarcie bramki.
+
+Każda odpowiedź pośrednia pokazuje:
+
+```text
+Etap:
+Wykonano:
+Następny dozwolony krok:
+Niedozwolone jeszcze:
+```
+
 ## Trigger i bramka intencji
 
 Task-plan uruchamia się przy:
@@ -283,8 +318,10 @@ Jeden materiał źródłowy tworzy jeden główny plan, który może zawierać w
 pakietów. Dekompozycja jest uzasadniona wtedy, gdy punkty mają różny cel,
 kryteria, zależności techniczne, moduł lub niezależność wdrożenia/testowania.
 Jeżeli te elementy tworzą jeden spójny zakres, zachowaj jeden pakiet zamiast
-dzielić go mechanicznie. Task-plan nie tworzy automatycznie nowych issue i nie
-wybiera workera.
+dzielić go mechanicznie. Pakiety można pokazać w draftcie wcześniej, ale
+decyzje `accept`, `revise`, `exclude` i `separate` wolno przedstawić użytkownikowi
+dopiero po otwarciu `package_decision_gate`. Task-plan nie tworzy automatycznie
+nowych issue i nie wybiera workera.
 
 Każdy pakiet ma stabilny identyfikator (`WP1`, `WP2`, ...), a jego rekord
 zawiera:
@@ -540,6 +577,7 @@ zatwierdzone wymaganie.
 Kontrakt planu używa następujących stanów:
 
 ```text
+review-pending
 needs-clarification
 awaiting-package-decisions
 review-limit-reached
@@ -556,10 +594,13 @@ excluded
 separated
 ```
 
-Znaczenie i przejścia są aktywną częścią kontraktu bloków B–C. Blok C dodaje
-review i wersjonowanie planu, ale nie zmienia semantyki stanów pakietów. W
-szczególności plan nie może być `approved`, gdy choć jeden pakiet pozostaje
-`pending` albo istnieje nierozwiązany blocker.
+Znaczenie i przejścia są aktywną częścią kontraktu bloków B–C. `review-pending`
+oznacza przygotowany draft, który nie przeszedł jeszcze kompletnego review i
+uproszczenia; w tym stanie nie wolno otwierać decyzji pakietowych.
+`needs-clarification` oznacza blocker lub decyzję zakresową wymagającą
+odpowiedzi użytkownika przed ponownym review. `review-limit-reached` wymaga
+jawnego ponowienia review. W szczególności plan nie może być `approved`, gdy
+choć jeden pakiet pozostaje `pending` albo istnieje nierozwiązany blocker.
 
 Minimalne przejścia pakietu:
 
@@ -577,27 +618,33 @@ użytkownika albo po wykazaniu wpływu zmiany zależności na jego zakres.
 Minimalne przejścia planu:
 
 ```text
+review-pending
+  → awaiting-package-decisions | needs-clarification | review-limit-reached
+
 needs-clarification
-  → awaiting-package-decisions
+  → review-pending
 
 awaiting-package-decisions
-  → approved | needs-clarification
-
-approved
-  → awaiting-package-decisions | approved
+  → approved | needs-clarification | review-pending
 
 review-limit-reached
-  → awaiting-package-decisions
+  → review-pending
+
+approved
+  → review-pending | approved
 ```
 
-`needs-clarification` oznacza, że review wykazał blocker wymagający decyzji
-zakresowej, biznesowej albo technicznej. `awaiting-package-decisions` może
-przejść do `approved` dopiero wtedy, gdy ostatnia wersja planu ma zakończony
-review, uproszczenie nie wymaga dalszej decyzji, wszystkie pakiety mają stan
-terminalny (`accepted`, `excluded` albo `separated`) i nie ma otwartych
-blockerów. Po osiągnięciu limitu review `review-limit-reached` pozostaje
-stanem jawnym; powrót do decyzji pakietowych wymaga świadomego ponowienia lub
-poprawki, a nie cichego kolejnego przebiegu.
+`awaiting-package-decisions` może zostać ustawiony wyłącznie po spełnieniu
+`package_decision_gate`: kompletne review, review krytyczny, brak otwartych
+findings/blockerów, zakończone uproszczenie i review kontrolne oraz brak
+nierozstrzygniętych decyzji zakresowych. Może przejść do `approved` dopiero
+wtedy, gdy wszystkie pakiety mają stan terminalny (`accepted`, `excluded` albo `separated`) i nie ma otwartych blockerów. Po osiągnięciu limitu review nie ma
+cichego przejścia do decyzji pakietowych — potrzebne jest jawne ponowienie
+review.
+
+`package_decision_gate` przyjmuje `closed` albo `open`. Dla draftu
+`review-pending` i `needs-clarification` pozostaje `closed`; formatter może
+renderować sekcje Work Package dopiero przy wartości `open`.
 
 ## Review planu i findings
 
@@ -630,6 +677,20 @@ Minimalny zakres review obejmuje:
 - przypadki brzegowe, obsługę błędów, testy i sposób weryfikacji;
 - ryzyko rozszerzenia zakresu oraz wpływ security, migracji i zależności.
 
+Pierwszy review jest formalnym **review krytycznym**. Jego rekord musi zawierać
+`stage: critical-review`, `complete: true` oraz wszystkie sprawdzenia:
+
+```text
+intent-and-acceptance
+technical-scope
+edge-cases-and-verification
+risks-and-dependencies
+```
+
+Stan planu zapisuje dodatkowo `critical_review_complete: true`. Sama obecność
+sekcji `Evidence, risks and review`, niepusty draft ani pozytywny wynik
+walidacji struktury nie spełniają tej bramki.
+
 ### Pętla review i rejestr rewizji
 
 Review wykonuj na konkretnej wersji planu, bez zmiany `Source plan`:
@@ -648,6 +709,10 @@ Każda iteracja ma jawny zapis:
 
 ```text
 Review #1
+- stage: critical-review
+- complete: true
+- checks: intent-and-acceptance, technical-scope,
+  edge-cases-and-verification, risks-and-dependencies
 - F1 HIGH: <claim> — open
 - F2 MEDIUM: <claim> — open
 
@@ -670,17 +735,93 @@ ponowieniu albo poprawce. Kontrolowany limit chroni przed nieskończoną pętlą
 
 ### Pytania i decyzje użytkownika
 
-Każde pytanie przypisz do pakietu i oznacz jako blokujące albo nieblokujące:
+Pytania dzielą się na dwa rodzaje. Decyzje zakresowe i produktowe, które mogą
+zmienić więcej niż jeden pakiet, zapisuj w top-level `scope_questions` i
+rozstrzygaj przed otwarciem `package_decision_gate`. Pytania dotyczące wyłącznie
+jednego pakietu zapisuj w `packages[].questions` i pokazuj dopiero przy decyzji
+tego pakietu.
+
+Każde pytanie jest strukturalnym rekordem z unikalnym, stabilnym ID:
 
 ```text
-Q1 [WP2][BLOCKING] Czy pakiet obejmuje także migrację danych?
-Q2 [WP3][NON-BLOCKING] Czy test ma być funkcjonalny czy integracyjny?
+scope_questions:
+  - id: SQ1
+    prompt: "Czy async ma być opt-in, czy domyślny dla wszystkich POST-ów grida?"
+    blocking: true
+    resolved: false
+    impact: "Zmienia kontrakt wszystkich pakietów runtime."
+    decision_needed: "Wybrać opt-in albo default async."
+
+packages[].questions:
+  - id: WP2-Q1
+    prompt: "Jakie kody HTTP i envelope JSON obowiązują dla błędów domenowych?"
+    blocking: true
+    resolved: false
+    impact: "Definiuje kryteria akceptacji WP2."
+    decision_needed: "Ustalić kody HTTP i format envelope."
 ```
 
-W stanie przekazywanym do walidatora `questions` jest tablicą. Pytanie blokujące
-może być zapisane jako rekord `{blocking: true, resolved: false}`; dopóki nie ma
-`resolved: true`, pakiet nie może przejść do terminalnego stanu ani do finalnej
-akceptacji. Pytania nieblokujące nie zatrzymują akceptacji.
+ID mają format `SQ<number>` dla pytań zakresowych oraz
+`WP<number>-Q<number>` dla pytań lokalnych. Każdy rekord musi zawierać
+`prompt`, `blocking`, `resolved`, `impact` i `decision_needed`. Pytania muszą
+być osobnymi rekordami — nie wolno scalać kilku pytań w jeden akapit ani używać
+formatu `**Pytania:** pytanie 1? pytanie 2?`.
+Jeżeli `resolved: true`, rekord musi dodatkowo zachować `answer`,
+`decision_source` i `decided_at`; formatter pokazuje tę odpowiedź przy pytaniu.
+Pytanie nierozstrzygnięte nie może zawierać częściowej odpowiedzi.
+Starsze pytania zapisane jako zwykłe stringi nie są cicho dzielone ani
+akceptowane jako decyzje; przy wznowieniu trzeba je jawnie znormalizować do
+rekordów.
+
+Jeżeli `package_decision_gate` jest zamknięta, formatter renderuje pytania
+zakresowe oraz komunikat, że decyzje pakietowe są niedostępne — nie renderuje
+sekcji WP ani akcji `accept/revise/exclude/separate`. Po otwarciu bramki
+renderuje sekcję w następującym układzie:
+
+```md
+## Decisions and open questions
+
+### Decyzje zakresowe przed decyzjami pakietowymi
+
+- **SQ1 [BLOCKING]** Czy async ma być opt-in, czy domyślny dla wszystkich POST-ów grida?
+  - Wpływ: zmienia kontrakt wszystkich pakietów runtime.
+  - Wymagana decyzja: wybrać `opt-in` albo `default async`.
+  - Status: `open`
+
+### WP2 — Runtime TypeScript/Stimulus
+
+**Status:** `pending`<br>
+**Dostępne decyzje:** `accept` / `revise` / `exclude` / `separate`
+
+#### Pytania blokujące
+
+- **WP2-Q1 [BLOCKING]** Jakie kody HTTP i envelope JSON obowiązują dla błędów domenowych?
+  - Wpływ: definiuje kryteria akceptacji WP2.
+  - Wymagana decyzja: ustalić kody HTTP i format envelope.
+  - Status: `open`
+
+#### Pytania nieblokujące
+
+- Brak.
+```
+
+Każdy pakiet ma obie podsekcje pytań; jeżeli lista jest pusta, formatter wypisuje
+`Brak.`. Jedno pytanie oznacza jedną decyzję. Pytania blokujące z
+`resolved: false` blokują terminalny stan pakietu i finalną akceptację, a
+nierozwiązane `scope_questions` blokują otwarcie `package_decision_gate`.
+Pytania nieblokujące nie zatrzymują akceptacji.
+Dla pakietu w stanie `accepted`, `excluded` albo `separated` formatter nie
+pokazuje zwykłych akcji decyzyjnych; wyświetla informację, że ponowne otwarcie
+wymaga jawnej prośby użytkownika.
+
+Odpowiedź użytkownika wskazuje ID pytania lub pakietu, np.:
+
+```text
+SQ1: default async
+WP2-Q1: 422 dla błędów domenowych, 403 dla uprawnień, 419 dla CSRF
+WP1: revise
+WP2: accept
+```
 
 Brak odpowiedzi nie jest akceptacją. Decyzja zachowuje co najmniej:
 
@@ -724,7 +865,8 @@ zależności, ograniczenia bezpieczeństwa oraz warunek finalnej akceptacji.
 Szczegół implementacyjny można scalić lub przenieść do referencji, ale nie
 wolno usuwać go, jeśli chroni kontrakt, dowód, decyzję, kryterium albo ryzyko.
 
-Po uproszczeniu wykonaj jeden kontrolny review i zapisz wynik:
+Po uproszczeniu wykonaj jeden kontrolny review i zapisz wynik oraz
+`simplification_control_review_complete: true`:
 
 ```text
 no-change | simplified | needs-user-decision
@@ -853,7 +995,8 @@ source_ref: https://github.com/owner/repo/issues/123
 issue: 123
 title: "Original issue title"
 input_profile: brief-request
-plan_status: awaiting-package-decisions
+plan_status: review-pending
+package_decision_gate: closed
 plan_version: 1
 simplification_status: pending
 fetched_at: 2026-01-01T00:00:00Z
@@ -919,6 +1062,12 @@ brancha. Task-plan może rozpocząć własny workflow dopiero po sukcesie wszyst
 wcześniejszych kroków `gh-issue-*`, w tym osobnego ustawienia statusu **In
 progress** przez `$gh-issue-status-set`.
 
+Przejście jest zależne od intencji użytkownika: jednoznaczne polecenie łączące
+start issue z przygotowaniem planu pozwala agentowi uruchomić task-plan po obu
+bramkach sukcesu. Samo polecenie rozpoczęcia pracy nad issue nie uruchamia
+task-plan; agent powinien wtedy zaproponować ten krok albo o niego zapytać.
+Tytuł lub opis issue nie zastępuje jawnej intencji planowania.
+
 `start.mjs` nie pobiera body ani komentarzy. Po bramce strukturalny wynik
 `runIssueStart()` przekazuje wyłącznie `owner`, `repo`, `issue_number`, `branch`
 i `base` (CLI zachowuje dotychczasowy komunikat tekstowy); task-plan pobiera
@@ -944,7 +1093,10 @@ Blok E jest walidowany przez:
 ./tests/fixtures/task-plan/draft-operations.json
 ./tests/fixtures/task-plan/draft-main.md
 ./tests/fixtures/task-plan/draft-derived.md
+./tests/fixtures/task-plan/questions.json
+./tests/fixtures/task-plan/draft-questions.md
 ./tests/skills/task-plan/task-plan-contract.test.mjs
+./tests/skills/task-plan/task-plan-questions.test.mjs
 ```
 
 Fixture'y opisują obserwowalne niezmienniki, a test sprawdza je względem tego
@@ -971,10 +1123,15 @@ lub środowiska.
 
 | Moduł | Odpowiedzialność | Główne API/komendy |
 |---|---|---|
-| `<skill_dir>/scripts/draft.mjs` | tożsamość, ścieżka, front matter, sekcje, resume i atomowy zapis | `buildSourceIdentity`, `buildDraftPath`, `validateDraftDocument`, `writeAtomicFile`, `writeSeparatedDraft`; `path`, `validate` |
-| `<skill_dir>/scripts/state.mjs` | jawne przejścia, decyzje, bulk pending, approval guard i graf zależności | `canTransition`, `applyPlanTransition`, `applyDecisionCommand`, `applyPackageDecision`, `canApprovePlan`, `getImpactedPackageIds`; `transition`, `parse-command` |
+| `<skill_dir>/scripts/draft.mjs` | tożsamość, ścieżka, front matter, sekcje, pytania, resume i atomowy zapis | `buildSourceIdentity`, `buildDraftPath`, `buildDraftMetadata`, `validateDraftDocument`, `renderQuestionSections`, `writeAtomicFile`, `writeSeparatedDraft`; `path`, `validate`, `render-questions` |
+| `<skill_dir>/scripts/state.mjs` | jawne przejścia, bramka decyzji pakietowych, walidacja pytań, decyzje, bulk pending, approval guard i graf zależności | `canTransition`, `applyPlanTransition`, `canOpenPackageDecisions`, `validateQuestionRecords`, `applyDecisionCommand`, `applyPackageDecision`, `canApprovePlan`, `getImpactedPackageIds`; `transition`, `parse-command` |
 | `<skill_dir>/scripts/source.mjs` | normalizacja GitHub/file/user input oraz bezpieczny odczyt źródeł | `normalizeGitHubIssue`, `normalizeFileSource`, `normalizeUserInput`, `refreshSource`; `normalize-file`, `normalize-user`, `fetch-github` |
 | `<skill_dir>/scripts/validate-plan.mjs` | findings, review limit, simplification invariants, draft/state i final approval | `validateFinding`, `validateReviewHistory`, `validateSimplification`, `validatePlanDocument`, `validateFinalApproval`; `validate`, `validate-state` |
+
+`validatePlanDocument --state` porównuje metadane draftu ze stanem workflow:
+`plan_status`, `plan_version`, `package_decision_gate`, `source_ref` oraz numer
+issue muszą być zgodne. Rozdzielnie poprawny draft i rozdzielnie poprawny state
+nie oznaczają poprawnego planu.
 
 Przykładowy przepływ punktowy:
 
@@ -985,6 +1142,8 @@ node <skill_dir>/scripts/draft.mjs path \
   --source-kind github-issue --issue 123 --title "Original issue title"
 node <skill_dir>/scripts/state.mjs parse-command \
   --value "accept-selected: WP1, WP2"
+node <skill_dir>/scripts/draft.mjs render-questions \
+  --file ./tests/fixtures/task-plan/questions.json
 node <skill_dir>/scripts/validate-plan.mjs validate \
   --file ./docs/draft/issue-123-original-issue-title-plan.md
 ```
@@ -1009,15 +1168,20 @@ Stan przekazywany do walidatora ma postać danych, nie instrukcji:
 
 ```json
 {
-  "plan_status": "awaiting-package-decisions",
+  "plan_status": "review-pending",
   "plan_version": 1,
   "packages": [],
   "findings": [],
   "review_history": [],
   "decisions": [],
-  "simplification": {"result": "no-change"},
+  "simplification": {"result": "pending"},
   "blockers": [],
-  "review_complete": true
+  "scope_questions": [],
+  "package_decision_gate": "closed",
+  "review_complete": false,
+  "critical_review_complete": false,
+  "simplification_status": "pending",
+  "simplification_control_review_complete": false
 }
 ```
 

--- a/.agents/skills/task-plan/scripts/draft.mjs
+++ b/.agents/skills/task-plan/scripts/draft.mjs
@@ -8,6 +8,8 @@ import {slugifyTitle} from "../../_shared/scripts/slugify-title.mjs";
 import {
     PLAN_STATUSES,
     SIMPLIFICATION_STATUSES,
+    TERMINAL_PACKAGE_STATUSES,
+    validateQuestionRecords,
 } from "./state.mjs";
 
 export const DRAFT_SECTIONS = Object.freeze([
@@ -152,6 +154,7 @@ export function validateDraftDocument(document, options = {}) {
     if (missingSections.length > 0) {
         errors.push(`Missing draft sections: ${missingSections.join(", ")}.`);
     }
+    errors.push(...validateQuestionPresentation(parsed.body, parsed.metadata));
 
     return {
         valid: errors.length === 0,
@@ -229,7 +232,8 @@ export function buildDraftMetadata(source, options = {}) {
         source_kind: kind,
         source_ref: requireValue(source?.source_ref, "source_ref"),
         input_profile: source.input_profile ?? "brief-request",
-        plan_status: options.planStatus ?? (source.input_profile === "title-only" ? "needs-clarification" : "awaiting-package-decisions"),
+        plan_status: options.planStatus ?? (source.input_profile === "title-only" ? "needs-clarification" : "review-pending"),
+        package_decision_gate: options.packageDecisionGate ?? "closed",
         plan_version: String(options.planVersion ?? 1),
         simplification_status: options.simplificationStatus ?? "pending",
         fetched_at: source.fetched_at ?? now,
@@ -238,6 +242,7 @@ export function buildDraftMetadata(source, options = {}) {
 
     if (metadata.input_profile === "title-only") {
         metadata.plan_status = "needs-clarification";
+        metadata.package_decision_gate = "closed";
     }
     if (kind === "github-issue") {
         metadata.issue = requireIssueId(source.issue_number ?? source.issue);
@@ -248,9 +253,106 @@ export function buildDraftMetadata(source, options = {}) {
         metadata.parent_issue = requireIssueId(source.issue_number ?? source.issue);
         metadata.work_package_id = requirePackageId(source.work_package_id);
         metadata.plan_status = "needs-clarification";
+        metadata.package_decision_gate = "closed";
     }
 
     return metadata;
+}
+
+export function renderQuestionSections(input = {}) {
+    const scopeQuestions = input.scope_questions ?? input.scopeQuestions ?? [];
+    const packages = input.packages ?? [];
+    const packageDecisionGate = input.package_decision_gate
+        ?? input.packageDecisionGate
+        ?? (["awaiting-package-decisions", "approved"].includes(input.plan_status) ? "open" : "closed");
+    const errors = validateQuestionRecords(scopeQuestions, {scope: "scope"});
+
+    if (!["open", "closed"].includes(packageDecisionGate)) {
+        errors.push("package_decision_gate must be open or closed.");
+    }
+
+    if (!Array.isArray(packages)) {
+        errors.push("packages must be an array.");
+    }
+
+    const packageRecords = Array.isArray(packages) ? packages : [];
+    for (const [index, packageRecord] of packageRecords.entries()) {
+        if (!packageRecord || typeof packageRecord !== "object" || Array.isArray(packageRecord)) {
+            errors.push(`Package ${index + 1} must be an object.`);
+            continue;
+        }
+        let packageId;
+        try {
+            packageId = requirePackageId(packageRecord.id);
+        } catch (error) {
+            errors.push(error instanceof DraftError ? error.message : String(error));
+            continue;
+        }
+        if (!Array.isArray(packageRecord.questions)) {
+            errors.push(`${packageId} must declare questions as an array.`);
+            continue;
+        }
+        errors.push(...validateQuestionRecords(packageRecord.questions, {packageId}).map((error) => {
+            return `${packageId}: ${error}`;
+        }));
+    }
+
+    if (errors.length > 0) {
+        throw new DraftError("INVALID_QUESTION_RECORDS", errors.join(" "), {errors});
+    }
+    if (packageDecisionGate === "open" && scopeQuestions.some((question) => question.resolved !== true)) {
+        throw new DraftError(
+            "PACKAGE_DECISION_GATE_FAILED",
+            "Package decision gate cannot open while scope questions remain unresolved.",
+        );
+    }
+
+    const lines = [
+        "## Decisions and open questions",
+        "",
+        "### Decyzje zakresowe przed decyzjami pakietowymi",
+        "",
+        ...renderQuestionList(scopeQuestions),
+    ];
+
+    if (packageDecisionGate !== "open") {
+        lines.push(
+            "",
+            "### Decyzje pakietowe",
+            "",
+            "- Niedostępne: `package_decision_gate` jest zamknięta. Najpierw zakończ review, uproszczenie i decyzje zakresowe.",
+        );
+        return `${lines.join("\n")}\n`;
+    }
+
+    for (const packageRecord of packageRecords) {
+        const packageId = requirePackageId(packageRecord.id);
+        const title = markdownInline(packageRecord.title ?? packageRecord.goal ?? packageId);
+        const questions = packageRecord.questions;
+        const blocking = questions.filter((question) => question.blocking === true);
+        const nonBlocking = questions.filter((question) => question.blocking !== true);
+        const decisionStatus = packageRecord.decision_status ?? "pending";
+        const decisionLine = TERMINAL_PACKAGE_STATUSES.includes(decisionStatus)
+            ? "**Decyzje:** Pakiet terminalny; ponowne otwarcie wymaga jawnej prośby użytkownika."
+            : "**Dostępne decyzje:** `accept` / `revise` / `exclude` / `separate`";
+        lines.push(
+            "",
+            `### ${packageId} — ${title}`,
+            "",
+            `**Status:** \`${markdownInline(decisionStatus)}\`<br>`,
+            decisionLine,
+            "",
+            "#### Pytania blokujące",
+            "",
+            ...renderQuestionList(blocking),
+            "",
+            "#### Pytania nieblokujące",
+            "",
+            ...renderQuestionList(nonBlocking),
+        );
+    }
+
+    return `${lines.join("\n")}\n`;
 }
 
 export function prepareResumeMetadata(existingMetadata, incomingSource, options = {}) {
@@ -328,6 +430,7 @@ function validateRequiredMetadata(metadata) {
         "source_ref",
         "input_profile",
         "plan_status",
+        "package_decision_gate",
         "plan_version",
         "simplification_status",
         "fetched_at",
@@ -355,6 +458,20 @@ function validateMetadataEnums(metadata) {
     }
     if (!SIMPLIFICATION_STATUSES.includes(metadata?.simplification_status)) {
         errors.push(`Invalid simplification_status: ${metadata?.simplification_status ?? ""}.`);
+    }
+    if (Object.hasOwn(metadata, "package_decision_gate")
+        && !["open", "closed"].includes(metadata.package_decision_gate)) {
+        errors.push(`Invalid package_decision_gate: ${metadata.package_decision_gate ?? ""}.`);
+    }
+    if (Object.hasOwn(metadata, "package_decision_gate")) {
+        const packageDecisionStatuses = ["awaiting-package-decisions", "approved"];
+        const reviewStatuses = ["review-pending", "needs-clarification", "review-limit-reached"];
+        if (packageDecisionStatuses.includes(metadata.plan_status) && metadata.package_decision_gate !== "open") {
+            errors.push("Package decision gate must be open before package decisions or approval.");
+        }
+        if (reviewStatuses.includes(metadata.plan_status) && metadata.package_decision_gate !== "closed") {
+            errors.push("Package decision gate must be closed before review is complete.");
+        }
     }
     if (!isPositiveInteger(metadata?.plan_version)) {
         errors.push("plan_version must be a positive integer.");
@@ -387,6 +504,65 @@ function validateKindMetadata(metadata, kind) {
         return validateGitHubMetadata(metadata);
     }
     return [];
+}
+
+function validateQuestionPresentation(body, metadata = {}) {
+    const heading = "## Decisions and open questions";
+    const start = body.indexOf(heading);
+    if (start < 0) {
+        return [];
+    }
+    const sectionStart = start + heading.length;
+    const remainder = body.slice(sectionStart);
+    const nextSection = remainder.search(/\n##\s/);
+    const section = nextSection >= 0 ? remainder.slice(0, nextSection) : remainder;
+    const errors = [];
+    if (!section.includes("### Decyzje zakresowe przed decyzjami pakietowymi")) {
+        errors.push("Question section must contain the scope questions subsection.");
+    }
+    const packageHeadings = [...section.matchAll(/^###\s+(WP[1-9][0-9]*)\s+—\s+.+$/gm)];
+    const packageDecisionGate = metadata.package_decision_gate;
+
+    if (packageDecisionGate === "closed") {
+        if (packageHeadings.length > 0) {
+            errors.push("A closed package decision gate must not contain Work Package decision sections.");
+        }
+        if (!section.includes("### Decyzje pakietowe")) {
+            errors.push("A closed package decision gate must contain the unavailable package decisions notice.");
+        }
+    }
+    if (packageDecisionGate === "open") {
+        if (packageHeadings.length === 0) {
+            errors.push("An open package decision gate must contain Work Package sections.");
+        }
+        errors.push(...packageHeadings.flatMap((match, index) => {
+            return validatePackageQuestionSection(match, index, packageHeadings, section);
+        }));
+    }
+
+    if (/\*\*Pytania:\*\*/i.test(section)) {
+        errors.push("Questions must be rendered as separate structured records, not an aggregate Pytania paragraph.");
+    }
+    return errors;
+}
+
+function validatePackageQuestionSection(match, index, packageHeadings, section) {
+    const packageStart = match.index ?? 0;
+    const packageEnd = packageHeadings[index + 1]?.index ?? section.length;
+    const packageSection = section.slice(packageStart, packageEnd);
+    const requiredSubsections = ["#### Pytania blokujące", "#### Pytania nieblokujące"];
+    const errors = requiredSubsections
+        .filter((subsection) => !packageSection.includes(subsection))
+        .map((subsection) => `${match[1]} is missing ${subsection}.`);
+
+    if (!packageSection.includes("**Status:**")) {
+        errors.push(`${match[1]} is missing its status.`);
+    }
+    if (!packageSection.includes("**Dostępne decyzje:**")
+        && !packageSection.includes("**Decyzje:** Pakiet terminalny")) {
+        errors.push(`${match[1]} is missing its decision instruction.`);
+    }
+    return errors;
 }
 
 function validateDerivedMetadata(metadata) {
@@ -566,12 +742,16 @@ function cliResult(parsed) {
         const source = fs.readFileSync(path.resolve(parsed.values.file), "utf8");
         return validateDraftDocument(source, {kind: parsed.values.kind ?? "main"});
     }
+    if (parsed.command === "render-questions") {
+        const source = JSON.parse(fs.readFileSync(path.resolve(parsed.values.file), "utf8"));
+        return {markdown: renderQuestionSections(source)};
+    }
     throw new DraftError("INVALID_COMMAND", "Use path or validate.");
 }
 
 function main(args) {
     if (args[0] === "--help") {
-        process.stdout.write("Usage: draft.mjs path --source-kind <kind> [--issue <id>] [--title <title>] | validate --file <path> [--kind <main|derived>]\n");
+        process.stdout.write("Usage: draft.mjs path --source-kind <kind> [--issue <id>] [--title <title>] | validate --file <path> [--kind <main|derived>] | render-questions --file <json>\n");
         return 0;
     }
     try {
@@ -585,6 +765,31 @@ function main(args) {
         process.stdout.write(`${JSON.stringify(result)}\n`);
         return CLI_CONTRACT_REJECTIONS.includes(result.code) ? 1 : 2;
     }
+}
+
+function renderQuestionList(questions) {
+    if (questions.length === 0) {
+        return ["- Brak."];
+    }
+
+    return questions.flatMap((question) => {
+        const marker = question.blocking ? "BLOCKING" : "NON-BLOCKING";
+        const status = question.resolved ? "resolved" : "open";
+        return [
+            `- **${question.id} [${marker}]** ${markdownInline(question.prompt)}`,
+            `  - Wpływ: ${markdownInline(question.impact)}`,
+            `  - Wymagana decyzja: ${markdownInline(question.decision_needed)}`,
+            `  - Status: \`${status}\``,
+            ...(question.resolved ? [`  - Odpowiedź: ${markdownInline(question.answer)}`] : []),
+        ];
+    });
+}
+
+function markdownInline(value) {
+    return String(value)
+        .replace(/\s+/g, " ")
+        .trim()
+        .replace(/[\\`*_]/g, "\\$&");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/.agents/skills/task-plan/scripts/state.mjs
+++ b/.agents/skills/task-plan/scripts/state.mjs
@@ -3,6 +3,7 @@
 import {pathToFileURL} from "node:url";
 
 export const PLAN_STATUSES = Object.freeze([
+    "review-pending",
     "needs-clarification",
     "awaiting-package-decisions",
     "review-limit-reached",
@@ -30,11 +31,22 @@ export const SIMPLIFICATION_STATUSES = Object.freeze([
     "needs-user-decision",
 ]);
 
+export const REQUIRED_REVIEW_CHECKS = Object.freeze([
+    "intent-and-acceptance",
+    "technical-scope",
+    "edge-cases-and-verification",
+    "risks-and-dependencies",
+]);
+
+const QUESTION_FIELDS = Object.freeze(["prompt", "impact", "decision_needed"]);
+const QUESTION_RESOLUTION_FIELDS = Object.freeze(["answer", "decision_source", "decided_at"]);
+
 export const PLAN_TRANSITIONS = Object.freeze({
-    "needs-clarification": Object.freeze(["awaiting-package-decisions"]),
-    "awaiting-package-decisions": Object.freeze(["approved", "needs-clarification"]),
-    "review-limit-reached": Object.freeze(["awaiting-package-decisions"]),
-    approved: Object.freeze(["awaiting-package-decisions", "approved"]),
+    "review-pending": Object.freeze(["awaiting-package-decisions", "needs-clarification", "review-limit-reached"]),
+    "needs-clarification": Object.freeze(["review-pending"]),
+    "awaiting-package-decisions": Object.freeze(["approved", "needs-clarification", "review-pending"]),
+    "review-limit-reached": Object.freeze(["review-pending"]),
+    approved: Object.freeze(["review-pending", "approved"]),
 });
 
 export const PACKAGE_TRANSITIONS = Object.freeze({
@@ -59,6 +71,7 @@ const CLI_CONTRACT_REJECTIONS = Object.freeze([
     "INVALID_TRANSITION",
     "UNKNOWN_STATUS",
     "APPROVAL_GUARD_FAILED",
+    "PACKAGE_DECISION_GATE_FAILED",
 ]);
 
 const CLI_ARGUMENT_ERRORS = Object.freeze([
@@ -75,12 +88,23 @@ export class StateError extends Error {
     }
 }
 
-export function canTransition(kind, from, to) {
+export function canTransition(kind, from, to, state = null) {
     const table = transitionTable(kind);
     if (!table) {
         return false;
     }
-    return Array.isArray(table[from]) && table[from].includes(to);
+    if (!Array.isArray(table[from]) || !table[from].includes(to)) {
+        return false;
+    }
+    if (kind === "plan" && to === "awaiting-package-decisions" && state !== null) {
+        return canOpenPackageDecisions(state).ready;
+    }
+    return true;
+}
+
+export function canOpenPackageDecisions(state) {
+    const reasons = packageDecisionGateReasons(state);
+    return {ready: reasons.length === 0, reasons};
 }
 
 export function assertTransition(kind, from, to) {
@@ -175,6 +199,16 @@ export function applyPlanTransition(state, nextStatus, context = {}) {
     const nextState = prepareState(state);
     const previousStatus = nextState.plan_status;
     assertTransition("plan", previousStatus, nextStatus);
+    if (nextStatus === "awaiting-package-decisions") {
+        const gate = canOpenPackageDecisions(nextState);
+        if (!gate.ready) {
+            throw new StateError("PACKAGE_DECISION_GATE_FAILED", `Package decisions cannot open: ${gate.reasons.join(", ")}.`, {
+                from: previousStatus,
+                to: nextStatus,
+                reasons: gate.reasons,
+            });
+        }
+    }
     if (nextStatus === "approved") {
         const approval = canApprovePlan(nextState);
         if (!approval.approved) {
@@ -186,7 +220,7 @@ export function applyPlanTransition(state, nextStatus, context = {}) {
         }
     }
     nextState.plan_status = nextStatus;
-    if (previousStatus === "approved" && nextStatus === "awaiting-package-decisions") {
+    if (previousStatus === "approved" && nextStatus === "review-pending") {
         nextState.plan_version += 1;
     }
     if (!Array.isArray(nextState.plan_history)) {
@@ -380,20 +414,103 @@ export function canApprovePlan(state) {
     }
     reasons.push(...missingDecisionRecordReasons(candidate, packages));
     reasons.push(...packageQuestionReasons(packages));
-    reasons.push(...blockerReasons(candidate));
-    if (Array.isArray(candidate.findings) && candidate.findings.some((finding) => {
-        return finding && ["CRITICAL", "HIGH"].includes(finding.severity)
-            && ["open", "reopened"].includes(finding.status);
-    })) {
-        reasons.push("open_high_findings");
+    for (const reason of packageDecisionGateReasons(candidate)) {
+        if (!reasons.includes(reason)) {
+            reasons.push(reason);
+        }
     }
-    if (candidate.review_complete !== true) {
-        reasons.push("review_incomplete");
-    }
-    reasons.push(...reviewHistoryReasons(candidate));
-    reasons.push(...simplificationReasons(candidate));
 
     return {approved: reasons.length === 0, reasons};
+}
+
+function packageDecisionGateReasons(state) {
+    const candidate = state && typeof state === "object" ? state : {};
+    const reasons = [];
+    const addReason = (reason) => {
+        if (!reasons.includes(reason)) {
+            reasons.push(reason);
+        }
+    };
+
+    if (Object.hasOwn(candidate, "package_decision_gate")
+        && candidate.package_decision_gate !== "open") {
+        addReason(candidate.package_decision_gate === "closed"
+            ? "package_decision_gate_closed"
+            : "invalid_package_decision_gate");
+    }
+
+    if (!Array.isArray(candidate.packages) || candidate.packages.length === 0) {
+        addReason("no_work_packages");
+    }
+    if (candidate.review_complete !== true) {
+        addReason("review_incomplete");
+    }
+    if (candidate.critical_review_complete !== true) {
+        addReason("critical_review_incomplete");
+    }
+    for (const reason of reviewHistoryReasons(candidate)) {
+        addReason(reason);
+    }
+    if (!hasCompletedCriticalReview(candidate.review_history)) {
+        addReason("critical_review_missing");
+    }
+    if (!["no-change", "simplified"].includes(candidate.simplification_status)) {
+        addReason("simplification_not_resolved");
+    }
+    if (candidate.simplification_control_review_complete !== true) {
+        addReason("simplification_review_incomplete");
+    }
+    for (const reason of simplificationReasons(candidate)) {
+        addReason(reason);
+    }
+    for (const reason of blockerReasons(candidate)) {
+        addReason(reason);
+    }
+
+    if (!Array.isArray(candidate.findings)) {
+        addReason("findings_missing");
+    } else if (candidate.findings.some((finding) => {
+        return finding && ["open", "reopened"].includes(finding.status);
+    })) {
+        addReason("open_actionable_findings");
+    }
+
+    if (!Array.isArray(candidate.scope_questions)) {
+        addReason("scope_questions_missing");
+    } else {
+        const scopeQuestionErrors = validateQuestionRecords(candidate.scope_questions, {scope: "scope"});
+        if (scopeQuestionErrors.length > 0) {
+            addReason("invalid_scope_questions");
+        } else if (candidate.scope_questions.some(isUnresolvedScopeQuestion)) {
+            addReason("unresolved_scope_questions");
+        }
+    }
+
+    return reasons;
+}
+
+function hasCompletedCriticalReview(history) {
+    if (!Array.isArray(history)) {
+        return false;
+    }
+
+    return history.some((review) => {
+        if (!review || review.stage !== "critical-review" || review.complete !== true) {
+            return false;
+        }
+        return Array.isArray(review.checks)
+            && REQUIRED_REVIEW_CHECKS.every((check) => review.checks.includes(check));
+    });
+}
+
+function isUnresolvedScopeQuestion(question) {
+    if (typeof question === "string") {
+        return question.trim() !== "";
+    }
+    return Boolean(question)
+        && typeof question === "object"
+        && !Array.isArray(question)
+        && question.resolved !== true;
 }
 
 export function readSimplificationResult(state) {
@@ -421,12 +538,71 @@ export function validatePackageRecords(packages) {
         }
         if (!Array.isArray(item.questions)) {
             errors.push(`${item.id ?? "Unknown package"} must declare questions as an array.`);
+        } else {
+            errors.push(...validateQuestionRecords(item.questions, {packageId: item.id}).map((error) => {
+                return `${item.id ?? "Unknown package"}: ${error}`;
+            }));
         }
     }
 
     const graphResult = validateDependencyGraph(records);
     errors.push(...graphResult.errors);
     return {valid: errors.length === 0, errors};
+}
+
+export function validateQuestionRecords(questions, options = {}) {
+    if (!Array.isArray(questions)) {
+        return ["Questions must be an array."];
+    }
+
+    const errors = [];
+    const ids = new Set();
+    const expectedId = options.scope === "scope"
+        ? /^SQ[1-9][0-9]*$/
+        : new RegExp(`^${escapeRegExp(options.packageId ?? "WP")}-Q[1-9][0-9]*$`);
+
+    for (const [index, question] of questions.entries()) {
+        const label = `Question ${index + 1}`;
+        if (!question || typeof question !== "object" || Array.isArray(question)) {
+            errors.push(`${label} must be a structured record.`);
+            continue;
+        }
+        if (typeof question.id !== "string" || !expectedId.test(question.id)) {
+            errors.push(`${label} id must match ${options.scope === "scope" ? "SQ<number>" : `${options.packageId ?? "WP<number>"}-Q<number>`}.`);
+        } else if (ids.has(question.id)) {
+            errors.push(`Duplicate question id: ${question.id}.`);
+        } else {
+            ids.add(question.id);
+        }
+        for (const field of QUESTION_FIELDS) {
+            if (typeof question[field] !== "string" || question[field].trim() === "") {
+                errors.push(`${label} is missing ${field}.`);
+            }
+        }
+        if (typeof question.blocking !== "boolean") {
+            errors.push(`${label} blocking must be boolean.`);
+        }
+        if (typeof question.resolved !== "boolean") {
+            errors.push(`${label} resolved must be boolean.`);
+        } else if (question.resolved) {
+            for (const field of QUESTION_RESOLUTION_FIELDS) {
+                if (typeof question[field] !== "string" || question[field].trim() === "") {
+                    errors.push(`${label} is missing ${field} for a resolved question.`);
+                }
+            }
+            if (typeof question.decided_at === "string" && Number.isNaN(Date.parse(question.decided_at))) {
+                errors.push(`${label} decided_at must be a valid timestamp.`);
+            }
+        } else if (QUESTION_RESOLUTION_FIELDS.some((field) => hasMeaningfulQuestionValue(question[field]))) {
+            errors.push(`${label} cannot contain an answer before resolved is true.`);
+        }
+    }
+
+    return errors;
+}
+
+function hasMeaningfulQuestionValue(value) {
+    return value !== null && typeof value !== "undefined" && String(value).trim() !== "";
 }
 
 export function validateDecisionHistory(decisions) {
@@ -486,7 +662,7 @@ function packageQuestionReasons(packages) {
             continue;
         }
         const questions = Array.isArray(item.questions) ? item.questions : [];
-        if (questions.some((question) => !isValidQuestionRecord(question))) {
+        if (validateQuestionRecords(questions, {packageId: item.id}).length > 0) {
             if (!reasons.includes("invalid_package_questions")) {
                 reasons.push("invalid_package_questions");
             }
@@ -499,25 +675,11 @@ function packageQuestionReasons(packages) {
 }
 
 function isUnresolvedBlockingQuestion(question) {
-    if (typeof question === "string") {
-        return /\[BLOCKING\]/i.test(question);
-    }
     return Boolean(question)
         && typeof question === "object"
         && !Array.isArray(question)
         && question.blocking === true
         && question.resolved !== true;
-}
-
-function isValidQuestionRecord(question) {
-    if (typeof question === "string") {
-        return true;
-    }
-    return Boolean(question)
-        && typeof question === "object"
-        && !Array.isArray(question)
-        && (!Object.hasOwn(question, "blocking") || typeof question.blocking === "boolean")
-        && (!Object.hasOwn(question, "resolved") || typeof question.resolved === "boolean");
 }
 
 function blockerReasons(candidate) {
@@ -565,14 +727,26 @@ function reviewHistoryReasons(candidate) {
         || candidate.review_history.length === 0) {
         return ["review_history_missing"];
     }
-    if (candidate.review_history.some((review) => {
-        return !review
+    const iterations = new Set();
+    let previousPlanVersion = 0;
+    for (const review of candidate.review_history) {
+        if (!review
             || typeof review !== "object"
             || !Number.isInteger(review.iteration)
             || review.iteration < 1
+            || iterations.has(review.iteration)
             || (Object.hasOwn(review, "plan_version")
-                && (!Number.isInteger(review.plan_version) || review.plan_version < 1));
-    })) {
+                && (!Number.isInteger(review.plan_version)
+                    || review.plan_version < 1
+                    || review.plan_version <= previousPlanVersion))) {
+            return ["invalid_review_history"];
+        }
+        iterations.add(review.iteration);
+        if (Object.hasOwn(review, "plan_version")) {
+            previousPlanVersion = review.plan_version;
+        }
+    }
+    if (candidate.review_history.length > 3) {
         return ["invalid_review_history"];
     }
     return [];
@@ -663,6 +837,10 @@ function hasDependencyCycle(packages) {
 
 function clone(value) {
     return JSON.parse(JSON.stringify(value));
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function parseArgs(args) {

--- a/.agents/skills/task-plan/scripts/validate-plan.mjs
+++ b/.agents/skills/task-plan/scripts/validate-plan.mjs
@@ -11,12 +11,14 @@ import {
 } from "./draft.mjs";
 import {
     canApprovePlan,
+    canOpenPackageDecisions,
     validateDecisionHistory,
     validatePackageRecords,
     PLAN_STATUSES,
     readSimplificationResult,
     SIMPLIFICATION_STATUSES,
     TERMINAL_PACKAGE_STATUSES,
+    validateQuestionRecords,
 } from "./state.mjs";
 
 export const FINDING_SEVERITIES = Object.freeze(["CRITICAL", "HIGH", "MEDIUM", "LOW"]);
@@ -150,10 +152,26 @@ export function validateSimplification(simplification) {
 }
 
 export function validatePlanState(state) {
-    const errors = [];
     if (!state || typeof state !== "object") {
         return {valid: false, errors: ["Plan state must be an object."]};
     }
+    const errors = [
+        ...validateStateMetadata(state),
+        ...validateStatePackages(state),
+        ...validateStateRecords(state),
+    ];
+    const approval = canApprovePlan(state);
+    errors.push(...validateStateApproval(state, approval));
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        approval,
+    };
+}
+
+function validateStateMetadata(state) {
+    const errors = [];
     if (!Number.isInteger(state.plan_version) || state.plan_version < 1) {
         errors.push("Plan state must contain a positive integer plan_version.");
     }
@@ -173,14 +191,42 @@ export function validatePlanState(state) {
     if (Object.hasOwn(state, "blockers") && !Array.isArray(state.blockers)) {
         errors.push("Plan state blockers must be an array.");
     }
+    for (const field of ["review_complete", "critical_review_complete", "simplification_control_review_complete"]) {
+        if (Object.hasOwn(state, field) && typeof state[field] !== "boolean") {
+            errors.push(`Plan state ${field} must be boolean.`);
+        }
+    }
+    if (Object.hasOwn(state, "scope_questions") && !Array.isArray(state.scope_questions)) {
+        errors.push("Plan state scope_questions must be an array.");
+    } else if (Array.isArray(state.scope_questions)) {
+        errors.push(...validateQuestionRecords(state.scope_questions, {scope: "scope"}).map((error) => {
+            return `scope_questions: ${error}`;
+        }));
+    }
+    if (Object.hasOwn(state, "package_decision_gate")
+        && !["open", "closed"].includes(state.package_decision_gate)) {
+        errors.push("Plan state package_decision_gate must be open or closed.");
+    } else if (Object.hasOwn(state, "package_decision_gate")) {
+        const expectedGate = ["awaiting-package-decisions", "approved"].includes(state.plan_status)
+            ? "open"
+            : ["review-pending", "needs-clarification", "review-limit-reached"].includes(state.plan_status)
+                ? "closed"
+                : null;
+        if (expectedGate && state.package_decision_gate !== expectedGate) {
+            errors.push(`Plan state package_decision_gate must be ${expectedGate} for ${state.plan_status}.`);
+        }
+    }
+    return errors;
+}
 
+function validateStatePackages(state) {
+    const errors = [];
     if (!Array.isArray(state.packages)) {
         errors.push("Plan state must contain a packages array.");
     } else if (["awaiting-package-decisions", "approved"].includes(state.plan_status) && state.packages.length === 0) {
         errors.push("Plan state must contain at least one work package before package decisions or approval.");
     }
-    const packageResult = validatePackageRecords(state.packages);
-    errors.push(...packageResult.errors);
+    errors.push(...validatePackageRecords(state.packages).errors);
     for (const [index, item] of (Array.isArray(state.packages) ? state.packages : []).entries()) {
         if (!item || typeof item !== "object") {
             continue;
@@ -194,7 +240,11 @@ export function validatePlanState(state) {
             errors.push(`Package ${index + 1} must contain goal, scope and acceptance criteria.`);
         }
     }
+    return errors;
+}
 
+function validateStateRecords(state) {
+    const errors = [];
     const decisions = state.decisions ?? [];
     errors.push(...validateDecisionHistory(decisions));
     if (Array.isArray(state.packages) && Array.isArray(decisions)) {
@@ -212,20 +262,24 @@ export function validatePlanState(state) {
         before: state.simplification_before,
         after: state.simplification_after,
     }));
+    return errors;
+}
 
-    const approval = canApprovePlan(state);
+function validateStateApproval(state, approval) {
+    const errors = [];
+    if (state.plan_status === "awaiting-package-decisions") {
+        const gate = canOpenPackageDecisions(state);
+        if (!gate.ready) {
+            errors.push(`Package decision gate failed: ${gate.reasons.join(", ")}.`);
+        }
+    }
     if (state.plan_status === "approved" && !approval.approved) {
         errors.push(`Approved plan failed approval guard: ${approval.reasons.join(", ")}.`);
     }
     if (state.plan_status === "approved" && (!Array.isArray(state.review_history) || state.review_history.length === 0)) {
         errors.push("Approved plan must contain review history.");
     }
-
-    return {
-        valid: errors.length === 0,
-        errors,
-        approval,
-    };
+    return errors;
 }
 
 export function validatePlanDocument(document, options = {}) {
@@ -236,6 +290,7 @@ export function validatePlanDocument(document, options = {}) {
 
     if (options.state) {
         errors.push(...validatePlanState(options.state).errors);
+        errors.push(...validateDraftStateConsistency(draftResult.metadata, options.state));
     }
 
     return {
@@ -244,6 +299,42 @@ export function validatePlanDocument(document, options = {}) {
         metadata: draftResult.metadata,
         missingSections: draftResult.missingSections,
     };
+}
+
+function validateDraftStateConsistency(metadata, state) {
+    const errors = [];
+    if (!state || typeof state !== "object") {
+        return errors;
+    }
+    if (typeof state.plan_status === "string"
+        && typeof metadata?.plan_status === "string"
+        && state.plan_status !== metadata.plan_status) {
+        errors.push(`Draft/state plan_status mismatch: draft=${metadata.plan_status}, state=${state.plan_status}.`);
+    }
+    if (Number.isInteger(state.plan_version)
+        && isPositiveInteger(metadata?.plan_version)
+        && Number(state.plan_version) !== Number(metadata.plan_version)) {
+        errors.push(`Draft/state plan_version mismatch: draft=${metadata.plan_version}, state=${state.plan_version}.`);
+    }
+    const expectedGate = ["awaiting-package-decisions", "approved"].includes(state.plan_status)
+        ? "open"
+        : ["review-pending", "needs-clarification", "review-limit-reached"].includes(state.plan_status)
+            ? "closed"
+            : null;
+    const stateGate = state.package_decision_gate ?? expectedGate;
+    if (stateGate && metadata?.package_decision_gate && stateGate !== metadata.package_decision_gate) {
+        errors.push(`Draft/state package_decision_gate mismatch: draft=${metadata.package_decision_gate}, state=${stateGate}.`);
+    }
+    if (typeof state.source_ref === "string"
+        && typeof metadata?.source_ref === "string"
+        && state.source_ref !== metadata.source_ref) {
+        errors.push("Draft/state source_ref mismatch.");
+    }
+    if (typeof state.issue !== "undefined" && typeof metadata?.issue !== "undefined"
+        && String(state.issue) !== String(metadata.issue)) {
+        errors.push("Draft/state issue mismatch.");
+    }
+    return errors;
 }
 
 export function validateFinalApproval(state) {
@@ -285,6 +376,11 @@ function containsAll(after, before) {
 
 function sameValue(left, right) {
     return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function isPositiveInteger(value) {
+    return (typeof value === "number" && Number.isInteger(value) && value > 0)
+        || (typeof value === "string" && /^[1-9][0-9]*$/.test(value));
 }
 
 function parseArgs(args) {

--- a/tests/fixtures/task-plan/draft-derived.md
+++ b/tests/fixtures/task-plan/draft-derived.md
@@ -6,6 +6,7 @@ parent_issue: 123
 parent_draft: issue-123-main-title-plan.md
 work_package_id: WP2
 plan_status: needs-clarification
+package_decision_gate: closed
 plan_version: 1
 simplification_status: pending
 fetched_at: 2026-01-01T00:00:00Z
@@ -27,7 +28,13 @@ The separated package has its own review scope.
 
 ## Decisions and open questions
 
-- No decision is inherited automatically from the parent draft.
+### Decyzje zakresowe przed decyzjami pakietowymi
+
+- Brak.
+
+### Decyzje pakietowe
+
+- Niedostępne: `package_decision_gate` jest zamknięta. Najpierw zakończ review, uproszczenie i decyzje zakresowe.
 
 ## Evidence, risks and review
 

--- a/tests/fixtures/task-plan/draft-main.md
+++ b/tests/fixtures/task-plan/draft-main.md
@@ -4,7 +4,8 @@ source_ref: https://github.com/acme/demo/issues/123
 issue: 123
 title: "Original issue title"
 input_profile: brief-request
-plan_status: awaiting-package-decisions
+plan_status: review-pending
+package_decision_gate: closed
 plan_version: 1
 simplification_status: pending
 fetched_at: 2026-01-01T00:00:00Z
@@ -22,13 +23,20 @@ Implement the explicitly accepted goal without expanding the source scope.
 
 ## Work packages
 
-- WP1 — core package, status `accepted`.
-- WP2 — package awaiting a separate decision.
-- WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-import-plan.md)
+- WP1 — core package, status `pending`.
+- WP2 — package pending review and a later decision.
+- No package decision is requested before the review gate opens.
+- After an explicit `separate`: WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-import-plan.md)
 
 ## Decisions and open questions
 
-- Q1 [WP2][BLOCKING] Czy pakiet obejmuje także migrację danych?
+### Decyzje zakresowe przed decyzjami pakietowymi
+
+- Brak.
+
+### Decyzje pakietowe
+
+- Niedostępne: `package_decision_gate` jest zamknięta. Najpierw zakończ review, uproszczenie i decyzje zakresowe.
 
 ## Evidence, risks and review
 
@@ -41,7 +49,7 @@ Implement the explicitly accepted goal without expanding the source scope.
 
 ## Next action
 
-Await package decisions.
+Run the critical review and simplification before opening package decisions.
 
 ## Execution handoff (when implementation is requested)
 

--- a/tests/fixtures/task-plan/draft-questions.md
+++ b/tests/fixtures/task-plan/draft-questions.md
@@ -1,0 +1,54 @@
+## Decisions and open questions
+
+### Decyzje zakresowe przed decyzjami pakietowymi
+
+- **SQ1 [BLOCKING]** Czy async ma być opt-in, czy domyślny dla wszystkich POST-ów grida?
+  - Wpływ: Zmienia kontrakt wszystkich pakietów runtime.
+  - Wymagana decyzja: Wybrać opt-in albo default async.
+  - Status: `resolved`
+  - Odpowiedź: default async
+
+### WP1 — Kontrakt backendu
+
+**Status:** `pending`<br>
+**Dostępne decyzje:** `accept` / `revise` / `exclude` / `separate`
+
+#### Pytania blokujące
+
+- **WP1-Q1 [BLOCKING]** Jakie kody HTTP obowiązują dla błędów domenowych, uprawnień i CSRF?
+  - Wpływ: Definiuje kryteria akceptacji kontraktu odpowiedzi.
+  - Wymagana decyzja: Wskazać kody HTTP.
+  - Status: `open`
+
+#### Pytania nieblokujące
+
+- Brak.
+
+### WP2 — Runtime TypeScript/Stimulus
+
+**Status:** `pending`<br>
+**Dostępne decyzje:** `accept` / `revise` / `exclude` / `separate`
+
+#### Pytania blokujące
+
+- Brak.
+
+#### Pytania nieblokujące
+
+- **WP2-Q1 [NON-BLOCKING]** Czy testy mają być funkcjonalne czy integracyjne?
+  - Wpływ: Wpływa na sposób weryfikacji pakietu.
+  - Wymagana decyzja: Wybrać preferowany typ testu.
+  - Status: `open`
+
+### WP3 — Flash alerty i live state
+
+**Status:** `pending`<br>
+**Dostępne decyzje:** `accept` / `revise` / `exclude` / `separate`
+
+#### Pytania blokujące
+
+- Brak.
+
+#### Pytania nieblokujące
+
+- Brak.

--- a/tests/fixtures/task-plan/questions.json
+++ b/tests/fixtures/task-plan/questions.json
@@ -1,0 +1,54 @@
+{
+  "package_decision_gate": "open",
+  "scope_questions": [
+    {
+      "id": "SQ1",
+      "prompt": "Czy async ma być opt-in, czy domyślny dla wszystkich POST-ów grida?",
+      "blocking": true,
+    "resolved": true,
+    "impact": "Zmienia kontrakt wszystkich pakietów runtime.",
+    "decision_needed": "Wybrać opt-in albo default async.",
+    "answer": "default async",
+    "decision_source": "user",
+    "decided_at": "2026-01-01T00:00:00Z"
+    }
+  ],
+  "packages": [
+    {
+      "id": "WP1",
+      "title": "Kontrakt backendu",
+      "decision_status": "pending",
+      "questions": [
+        {
+          "id": "WP1-Q1",
+          "prompt": "Jakie kody HTTP obowiązują dla błędów domenowych, uprawnień i CSRF?",
+          "blocking": true,
+          "resolved": false,
+          "impact": "Definiuje kryteria akceptacji kontraktu odpowiedzi.",
+          "decision_needed": "Wskazać kody HTTP."
+        }
+      ]
+    },
+    {
+      "id": "WP2",
+      "title": "Runtime TypeScript/Stimulus",
+      "decision_status": "pending",
+      "questions": [
+        {
+          "id": "WP2-Q1",
+          "prompt": "Czy testy mają być funkcjonalne czy integracyjne?",
+          "blocking": false,
+          "resolved": false,
+          "impact": "Wpływa na sposób weryfikacji pakietu.",
+          "decision_needed": "Wybrać preferowany typ testu."
+        }
+      ]
+    },
+    {
+      "id": "WP3",
+      "title": "Flash alerty i live state",
+      "decision_status": "pending",
+      "questions": []
+    }
+  ]
+}

--- a/tests/fixtures/task-plan/status-transitions.json
+++ b/tests/fixtures/task-plan/status-transitions.json
@@ -22,23 +22,30 @@
   },
   "plan": {
     "allowed": [
-      {"from": "needs-clarification", "to": "awaiting-package-decisions"},
+      {"from": "review-pending", "to": "awaiting-package-decisions"},
+      {"from": "review-pending", "to": "needs-clarification"},
+      {"from": "review-pending", "to": "review-limit-reached"},
+      {"from": "needs-clarification", "to": "review-pending"},
       {"from": "awaiting-package-decisions", "to": "approved"},
       {"from": "awaiting-package-decisions", "to": "needs-clarification"},
-      {"from": "approved", "to": "awaiting-package-decisions"},
-      {"from": "approved", "to": "approved"},
-      {"from": "review-limit-reached", "to": "awaiting-package-decisions"}
+      {"from": "awaiting-package-decisions", "to": "review-pending"},
+      {"from": "review-limit-reached", "to": "review-pending"},
+      {"from": "approved", "to": "review-pending"},
+      {"from": "approved", "to": "approved"}
     ],
     "forbidden": [
       {"from": "needs-clarification", "to": "approved"},
+      {"from": "needs-clarification", "to": "awaiting-package-decisions"},
       {"from": "awaiting-package-decisions", "to": "review-limit-reached"},
-      {"from": "review-limit-reached", "to": "approved"}
+      {"from": "review-limit-reached", "to": "approved"},
+      {"from": "review-limit-reached", "to": "awaiting-package-decisions"}
     ],
     "contract_anchors": [
-      "needs-clarification\n  → awaiting-package-decisions",
-      "awaiting-package-decisions\n  → approved | needs-clarification",
-      "approved\n  → awaiting-package-decisions | approved",
-      "review-limit-reached\n  → awaiting-package-decisions"
+      "review-pending\n  → awaiting-package-decisions | needs-clarification | review-limit-reached",
+      "needs-clarification\n  → review-pending",
+      "awaiting-package-decisions\n  → approved | needs-clarification | review-pending",
+      "review-limit-reached\n  → review-pending",
+      "approved\n  → review-pending | approved"
     ]
   }
 }

--- a/tests/fixtures/task-plan/workflow-scenarios.json
+++ b/tests/fixtures/task-plan/workflow-scenarios.json
@@ -56,7 +56,7 @@
         "body": "Create two independently reviewable packages."
       },
       "expected": {
-        "plan_status": "awaiting-package-decisions",
+        "plan_status": "review-pending",
         "implementation_started": false
       },
       "required_anchors": [
@@ -89,6 +89,15 @@
         "Source plan",
         "Review findings",
         "Revised plan",
+        "review-pending",
+        "package_decision_gate",
+        "critical-review",
+        "simplification_control_review_complete",
+        "scope_questions",
+        "WP<number>-Q<number>",
+        "Pytania blokujące",
+        "Pytania nieblokujące",
+        "Brak.",
         "terminalny (`accepted`, `excluded` albo `separated`)",
         "nie ma otwartych",
         "approved",
@@ -108,7 +117,7 @@
         "base": "main"
       },
       "expected": {
-        "plan_status": "awaiting-package-decisions",
+        "plan_status": "review-pending",
         "implementation_started": false
       },
       "required_anchors": [

--- a/tests/skills/task-plan/task-plan-contract.test.mjs
+++ b/tests/skills/task-plan/task-plan-contract.test.mjs
@@ -8,6 +8,7 @@ import {buildDraftMetadata} from "../../../.agents/skills/task-plan/scripts/draf
 import {
     applyPlanTransition,
     canApprovePlan,
+    canOpenPackageDecisions,
     parseDecisionCommand,
 } from "../../../.agents/skills/task-plan/scripts/state.mjs";
 import {normalizeGitHubIssue} from "../../../.agents/skills/task-plan/scripts/source.mjs";
@@ -31,6 +32,7 @@ const TASK_PLAN_SCRIPTS = [
 ];
 
 const PLAN_STATUSES = new Set([
+    "review-pending",
     "needs-clarification",
     "awaiting-package-decisions",
     "review-limit-reached",
@@ -112,13 +114,28 @@ describe("task-plan workflow scenarios", () => {
                 decision_source: "user",
                 decided_at: "2026-01-01T00:00:00Z",
             }],
-            findings: [],
-            review_history: [{iteration: 1, plan_version: 1}],
+            review_history: [{
+                iteration: 1,
+                plan_version: 1,
+                stage: "critical-review",
+                complete: true,
+                checks: [
+                    "intent-and-acceptance",
+                    "technical-scope",
+                    "edge-cases-and-verification",
+                    "risks-and-dependencies",
+                ],
+            }],
             review_complete: true,
+            critical_review_complete: true,
             simplification_status: "no-change",
             simplification: {result: "no-change"},
+            simplification_control_review_complete: true,
             blockers: [],
+            findings: [],
+            scope_questions: [],
         };
+        expect(canOpenPackageDecisions(approvedState)).toEqual({ready: true, reasons: []});
         expect(canApprovePlan(approvedState).approved).toBe(true);
         expect(validateFinalApproval(approvedState).valid).toBe(true);
         const reviewScenario = WORKFLOW_SCENARIOS.find(({id}) => id === "review-and-approval");
@@ -126,6 +143,21 @@ describe("task-plan workflow scenarios", () => {
             reason: "fixture approval",
             changed_at: "2026-01-01T00:00:00Z",
         }).plan_status).toBe(reviewScenario.expected.plan_status);
+    });
+
+    it("keeps package decisions closed for an initial non-title draft", () => {
+        const source = normalizeGitHubIssue({
+            owner: "acme",
+            repo: "demo",
+            number: 458,
+            title: "Handle async grid actions",
+            body: "Prepare the implementation plan.",
+            comments: [],
+            branch: "issue/458-async-grid-actions",
+            base: "origin/main",
+        }, {fetchedAt: "2026-01-01T00:00:00Z"});
+
+        expect(buildDraftMetadata(source, {now: "2026-01-01T00:00:00Z"}).plan_status).toBe("review-pending");
     });
 });
 
@@ -177,7 +209,8 @@ describe("task-plan draft operations", () => {
             issue: "123",
             title: "Original issue title",
             input_profile: "brief-request",
-            plan_status: "awaiting-package-decisions",
+            plan_status: "review-pending",
+            package_decision_gate: "closed",
             plan_version: "1",
             simplification_status: "pending",
         });
@@ -230,10 +263,14 @@ describe("task-plan integration boundary", () => {
 
     it("keeps start.mjs free of source body/comment fetching and keeps the index entry", () => {
         const startSource = fs.readFileSync(path.join(ROOT, ".agents/skills/gh-issue-start/scripts/start.mjs"), "utf8");
+        const startSkill = fs.readFileSync(path.join(ROOT, ".agents/skills/gh-issue-start/SKILL.md"), "utf8");
         const skillsIndex = fs.readFileSync(path.join(ROOT, "docs/SKILLS.md"), "utf8");
 
         expect(startSource).not.toContain("comments");
         expect(startSource).not.toContain("number,title,body,comments");
+        expect(startSkill).toContain("Następne działanie po sukcesie");
+        expect(startSkill).toContain("nie oznacza automatycznego uruchomienia `$task-plan`");
+        expect(startSkill).toContain("sam tytuł lub opis issue nie jest wystarczającym dowodem intencji planowania");
         expect(skillsIndex).toContain("$task-plan");
     });
 

--- a/tests/skills/task-plan/task-plan-questions.test.mjs
+++ b/tests/skills/task-plan/task-plan-questions.test.mjs
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import path from "node:path";
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+
+import {
+    renderQuestionSections,
+    validateDraftDocument,
+} from "../../../.agents/skills/task-plan/scripts/draft.mjs";
+import {
+    validateQuestionRecords,
+} from "../../../.agents/skills/task-plan/scripts/state.mjs";
+import {validatePlanDocument} from "../../../.agents/skills/task-plan/scripts/validate-plan.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../");
+const QUESTIONS = JSON.parse(fs.readFileSync(path.join(ROOT, "tests/fixtures/task-plan/questions.json"), "utf8"));
+const EXPECTED_MARKDOWN = fs.readFileSync(path.join(ROOT, "tests/fixtures/task-plan/draft-questions.md"), "utf8");
+const MAIN_DRAFT = fs.readFileSync(path.join(ROOT, "tests/fixtures/task-plan/draft-main.md"), "utf8");
+const DRAFT_SCRIPT = path.join(ROOT, ".agents/skills/task-plan/scripts/draft.mjs");
+
+describe("task-plan question contract", () => {
+    it("renders scope and per-package questions as separate readable sections", () => {
+        expect(renderQuestionSections(QUESTIONS)).toBe(EXPECTED_MARKDOWN);
+
+        const cliResult = spawnSync(process.execPath, [DRAFT_SCRIPT, "render-questions", "--file", path.join(ROOT, "tests/fixtures/task-plan/questions.json")], {
+            cwd: ROOT,
+            encoding: "utf8",
+        });
+        expect(cliResult.status).toBe(0);
+        expect(JSON.parse(cliResult.stdout).markdown).toBe(EXPECTED_MARKDOWN);
+    });
+
+    it("requires stable IDs and structured question fields", () => {
+        expect(validateQuestionRecords(QUESTIONS.scope_questions, {scope: "scope"})).toEqual([]);
+        expect(validateQuestionRecords(QUESTIONS.packages[0].questions, {packageId: "WP1"})).toEqual([]);
+        expect(validateQuestionRecords([
+            {
+                id: "Q1",
+                prompt: "Two decisions?",
+                blocking: true,
+                resolved: false,
+            },
+        ], {packageId: "WP1"})).toEqual(expect.arrayContaining([
+            "Question 1 id must match WP1-Q<number>.",
+            "Question 1 is missing impact.",
+            "Question 1 is missing decision_needed.",
+        ]));
+        expect(validateQuestionRecords([{
+            id: "SQ1",
+            prompt: "Czy zakres jest właściwy?",
+            blocking: true,
+            resolved: true,
+            impact: "Zmienia zakres.",
+            decision_needed: "Potwierdzić zakres.",
+        }], {scope: "scope"})).toEqual(expect.arrayContaining([
+            "Question 1 is missing answer for a resolved question.",
+            "Question 1 is missing decision_source for a resolved question.",
+            "Question 1 is missing decided_at for a resolved question.",
+        ]));
+    });
+
+    it("rejects aggregate legacy question paragraphs and duplicate IDs", () => {
+        expect(() => renderQuestionSections({
+            scope_questions: [],
+            packages: [{
+                id: "WP1",
+                title: "Backend",
+                questions: ["Czy A? Czy B?"],
+            }],
+        })).toThrow("structured record");
+
+        expect(validateQuestionRecords([
+            {
+                id: "SQ1",
+                prompt: "Pytanie 1?",
+                blocking: true,
+                resolved: false,
+                impact: "Zakres",
+                decision_needed: "Odpowiedź",
+            },
+            {
+                id: "SQ1",
+                prompt: "Pytanie 2?",
+                blocking: false,
+                resolved: false,
+                impact: "Zakres",
+                decision_needed: "Odpowiedź",
+            },
+        ], {scope: "scope"})).toContain("Duplicate question id: SQ1.");
+
+        const legacyDraft = MAIN_DRAFT.replace(
+            "## Decisions and open questions",
+            "## Decisions and open questions\n\n**Pytania:** Czy A? Czy B?",
+        );
+        expect(validateDraftDocument(legacyDraft, {kind: "main"}).errors).toContain(
+            "Questions must be rendered as separate structured records, not an aggregate Pytania paragraph.",
+        );
+
+        const unresolvedScope = {...QUESTIONS.scope_questions[0], resolved: false};
+        delete unresolvedScope.answer;
+        delete unresolvedScope.decision_source;
+        delete unresolvedScope.decided_at;
+        expect(() => renderQuestionSections({
+            ...QUESTIONS,
+            scope_questions: [unresolvedScope],
+        })).toThrow("Package decision gate cannot open");
+    });
+
+    it("validates the full rendered package layout in a draft", () => {
+        const openDraft = MAIN_DRAFT
+            .replace("plan_status: review-pending", "plan_status: awaiting-package-decisions")
+            .replace("package_decision_gate: closed", "package_decision_gate: open")
+            .replace(
+                /## Decisions and open questions[\s\S]*?(?=\n## Evidence, risks and review)/,
+                `${EXPECTED_MARKDOWN}\n`,
+            );
+        expect(validateDraftDocument(openDraft, {kind: "main"}).valid).toBe(true);
+
+        const malformed = openDraft.replace("#### Pytania nieblokujące", "#### Brakująca sekcja");
+        expect(validateDraftDocument(malformed, {kind: "main"}).errors).toContain(
+            "WP1 is missing #### Pytania nieblokujące.",
+        );
+    });
+
+    it("does not expose package decisions while the gate is closed", () => {
+        const markdown = renderQuestionSections({...QUESTIONS, package_decision_gate: "closed"});
+
+        expect(markdown).toContain("### Decyzje pakietowe");
+        expect(markdown).toContain("package_decision_gate` jest zamknięta");
+        expect(markdown).not.toContain("### WP1 — Kontrakt backendu");
+        expect(markdown).not.toContain("WP1-Q1");
+    });
+
+    it("does not offer ordinary actions for terminal packages", () => {
+        const markdown = renderQuestionSections({
+            ...QUESTIONS,
+            packages: QUESTIONS.packages.map((packageRecord) => packageRecord.id === "WP1"
+                ? {...packageRecord, decision_status: "accepted"}
+                : packageRecord),
+        });
+
+        expect(markdown).toContain("Pakiet terminalny; ponowne otwarcie wymaga jawnej prośby użytkownika.");
+        expect(markdown).not.toContain("### WP1 — Kontrakt backendu\n\n**Status:** `accepted`<br>\n**Dostępne decyzje:**");
+    });
+
+    it("rejects draft and state lifecycle mismatches", () => {
+        const state = {
+            plan_status: "review-pending",
+            package_decision_gate: "closed",
+            plan_version: 1,
+            packages: [],
+            findings: [],
+            review_history: [],
+            decisions: [],
+            simplification: {result: "pending"},
+            simplification_status: "pending",
+            blockers: [],
+            scope_questions: [],
+            review_complete: false,
+            critical_review_complete: false,
+            simplification_control_review_complete: false,
+        };
+        expect(validatePlanDocument(MAIN_DRAFT, {kind: "main", state}).valid).toBe(true);
+        const mismatch = validatePlanDocument(MAIN_DRAFT, {
+            kind: "main",
+            state: {...state, plan_status: "needs-clarification"},
+        });
+        expect(mismatch.valid).toBe(false);
+        expect(mismatch.errors).toContain("Draft/state plan_status mismatch: draft=review-pending, state=needs-clarification.");
+
+        const gateMismatch = validatePlanDocument(MAIN_DRAFT, {
+            kind: "main",
+            state: {...state, package_decision_gate: "open"},
+        });
+        expect(gateMismatch.valid).toBe(false);
+        expect(gateMismatch.errors).toContain("Plan state package_decision_gate must be closed for review-pending.");
+    });
+});

--- a/tests/skills/task-plan/task-plan-scripts.test.mjs
+++ b/tests/skills/task-plan/task-plan-scripts.test.mjs
@@ -21,6 +21,7 @@ import {
     applyPackageDecision,
     applyPlanTransition,
     canApprovePlan,
+    canOpenPackageDecisions,
     canTransition,
     getImpactedPackageIds,
     parseDecisionCommand,
@@ -96,7 +97,7 @@ describe("task-plan draft module", () => {
 
         const titleOnly = MAIN_FIXTURE
             .replace("input_profile: brief-request", "input_profile: title-only")
-            .replace("plan_status: awaiting-package-decisions", "plan_status: approved");
+            .replace("plan_status: review-pending", "plan_status: approved");
         expect(validateDraftDocument(titleOnly, {kind: "main"}).valid).toBe(false);
         expect(validateDraftDocument(DERIVED_FIXTURE, {kind: "derived"}).valid).toBe(true);
     });
@@ -197,10 +198,55 @@ describe("task-plan state module", () => {
             reason: "all decisions complete",
             changed_at: "2026-01-02T00:00:00Z",
         }), "INVALID_TRANSITION");
-        expect(applyPlanTransition({...baseState(), plan_status: "approved"}, "awaiting-package-decisions", {
+        expect(applyPlanTransition({...baseState(), plan_status: "approved"}, "review-pending", {
             reason: "user requested corrections",
             changed_at: "2026-01-02T00:00:00Z",
         }).plan_version).toBe(2);
+    });
+
+    it("requires the review and simplification gate before package decisions", () => {
+        const incomplete = {
+            ...baseState(),
+            plan_status: "review-pending",
+            review_complete: false,
+            critical_review_complete: false,
+            review_history: [],
+            simplification_status: "pending",
+            simplification: {result: "pending"},
+            simplification_control_review_complete: false,
+        };
+
+        expect(canOpenPackageDecisions(incomplete).ready).toBe(false);
+        expect(canTransition("plan", "review-pending", "awaiting-package-decisions", incomplete)).toBe(false);
+        expectErrorCode(() => applyPlanTransition(incomplete, "awaiting-package-decisions", {
+            reason: "premature package decision request",
+            changed_at: "2026-01-02T00:00:00Z",
+        }), "PACKAGE_DECISION_GATE_FAILED");
+        expect(validatePlanState({...incomplete, plan_status: "awaiting-package-decisions"}).valid).toBe(false);
+
+        const ready = {
+            ...baseState(),
+            plan_status: "review-pending",
+        };
+        expect(canOpenPackageDecisions(ready)).toEqual({ready: true, reasons: []});
+        expect(canTransition("plan", "review-pending", "awaiting-package-decisions", ready)).toBe(true);
+        expect(applyPlanTransition(ready, "awaiting-package-decisions", {
+            reason: "critical review and simplification complete",
+            changed_at: "2026-01-02T00:00:00Z",
+        }).plan_status).toBe("awaiting-package-decisions");
+
+        const scopeBlocked = {
+            ...ready,
+            scope_questions: [{
+                id: "SQ1",
+                prompt: "Czy zakres obejmuje migrację?",
+                blocking: false,
+                resolved: false,
+                impact: "Zmienia zakres pakietów.",
+                decision_needed: "Potwierdzić zakres.",
+            }],
+        };
+        expect(canOpenPackageDecisions(scopeBlocked).reasons).toContain("unresolved_scope_questions");
     });
 
     it("parses only explicit decision commands", () => {
@@ -276,10 +322,14 @@ describe("task-plan state module", () => {
             ...accepted,
             plan_status: "awaiting-package-decisions",
             review_complete: true,
-            review_history: [{iteration: 1, plan_version: 1}],
+            critical_review_complete: true,
+            review_history: [criticalReview()],
             simplification_status: "no-change",
             simplification: {result: "no-change"},
+            simplification_control_review_complete: true,
             blockers: [],
+            findings: [],
+            scope_questions: [],
         };
 
         expect(canApprovePlan(ready)).toEqual({approved: true, reasons: []});
@@ -293,7 +343,14 @@ describe("task-plan state module", () => {
         expectErrorCode(() => applyPackageDecision({
             ...baseState(),
             packages: baseState().packages.map((item, index) => index === 0
-                ? {...item, questions: [{blocking: true, resolved: false}]}
+                ? {...item, questions: [{
+                    id: `${item.id}-Q1`,
+                    prompt: "Czy pytanie blokujące zostało rozstrzygnięte?",
+                    blocking: true,
+                    resolved: false,
+                    impact: "Blokuje decyzję pakietu.",
+                    decision_needed: "Potwierdzić odpowiedź.",
+                }]}
                 : item),
         }, {
             package_id: "WP1",
@@ -310,16 +367,27 @@ describe("task-plan state module", () => {
             ...accepted,
             plan_status: "awaiting-package-decisions",
             review_complete: true,
-            review_history: [{iteration: 1, plan_version: 1}],
+            critical_review_complete: true,
+            review_history: [criticalReview()],
             simplification_status: "no-change",
             simplification: {result: "no-change"},
+            simplification_control_review_complete: true,
             blockers: [],
+            findings: [],
+            scope_questions: [],
         };
 
         expect(validateFinalApproval({
             ...ready,
             packages: ready.packages.map((item, index) => index === 0
-                ? {...item, questions: [{blocking: true, resolved: false}]}
+                ? {...item, questions: [{
+                    id: `${item.id}-Q1`,
+                    prompt: "Czy pytanie blokujące zostało rozstrzygnięte?",
+                    blocking: true,
+                    resolved: false,
+                    impact: "Blokuje decyzję pakietu.",
+                    decision_needed: "Potwierdzić odpowiedź.",
+                }]}
                 : item),
         }).valid).toBe(false);
         expect(validateFinalApproval({...ready, blockers: "B1"}).valid).toBe(false);
@@ -478,10 +546,14 @@ describe("task-plan validation module", () => {
             ...approved,
             plan_status: "approved",
             review_complete: true,
-            review_history: [{iteration: 1, plan_version: 1}],
+            critical_review_complete: true,
+            review_history: [criticalReview()],
             simplification_status: "no-change",
             simplification: {result: "no-change"},
+            simplification_control_review_complete: true,
             blockers: [],
+            findings: [],
+            scope_questions: [],
         }).valid).toBe(true);
     });
 });
@@ -492,7 +564,7 @@ describe("task-plan CLI contract", () => {
         const invalidDraft = path.join(directory, "invalid.md");
         fs.writeFileSync(invalidDraft, MAIN_FIXTURE
             .replace("input_profile: brief-request", "input_profile: title-only")
-            .replace("plan_status: awaiting-package-decisions", "plan_status: approved"), "utf8");
+            .replace("plan_status: review-pending", "plan_status: approved"), "utf8");
 
         const draftResult = runCli(DRAFT_SCRIPT, ["validate", "--file", invalidDraft]);
         expect(draftResult.status).toBe(1);
@@ -547,12 +619,30 @@ function baseState() {
             },
         ],
         findings: [],
-        review_history: [],
+        review_history: [criticalReview()],
         simplification: {result: "no-change"},
         simplification_status: "no-change",
+        critical_review_complete: true,
+        simplification_control_review_complete: true,
         blockers: [],
         review_complete: true,
+        scope_questions: [],
         decisions: [],
+    };
+}
+
+function criticalReview() {
+    return {
+        iteration: 1,
+        plan_version: 1,
+        stage: "critical-review",
+        complete: true,
+        checks: [
+            "intent-and-acceptance",
+            "technical-scope",
+            "edge-cases-and-verification",
+            "risks-and-dependencies",
+        ],
     };
 }
 


### PR DESCRIPTION
## Zmiany ogólne
- Wymuszono przejście draftu przez review, uproszczenie i bramkę decyzji Work Package oraz dodano spójność metadanych draftu ze stanem workflow.
- Dodano strukturalne pytania zakresowe i pakietowe z ID, przechowywaniem odpowiedzi oraz czytelnym renderowaniem Markdown.
- Uzupełniono walidację layoutu, stanów terminalnych i regresji w fixture’ach oraz testach.

## Zmiany API poleceń CLI
- Dodano polecenie draft.mjs render-questions do generowania sekcji pytań z kontrolą package_decision_gate.