### PR TITLE
feat: dodano obserwowalność celów odczytu i diagnostykę OWE

### DIFF
--- a/.agents/skills/_shared/references/context-scout-report-protocol.md
+++ b/.agents/skills/_shared/references/context-scout-report-protocol.md
@@ -39,6 +39,10 @@ outside the scout's read set and why the parent may need it. `--claim` and
 `--evidence` are for `add-finding`. `add-risk`, `add-omitted` and `set-next-step`
 require `--text`. Do not hand-write the final JSON.
 
+`add-covered-path` may additionally receive `--purpose`, `--source` and
+`--read-mode` to record declared read context. These fields are validated against
+the shared read-purpose enum and do not prove freshness or non-redundancy.
+
 Ledger and report output paths must be under `var/agent/cache` or the system
 temporary directory. The builder rejects writes to source and configuration
 paths.

--- a/.agents/skills/_shared/references/context-subagent-contract.md
+++ b/.agents/skills/_shared/references/context-subagent-contract.md
@@ -216,7 +216,7 @@ Opcjonalne `read_coverage` opisuje read-set przekazywany rodzicowi:
 {
   "read_coverage": {
     "covered": [
-      {"path": "repo/file", "line_start": 1, "line_end": 2, "locator": "Symbol", "relation": "defines"}
+      {"path": "repo/file", "line_start": 1, "line_end": 2, "locator": "Symbol", "relation": "defines", "purpose": "discovery", "source": "scout", "read_mode": "range"}
     ],
     "follow_up": [
       {"path": "repo/other-file", "reason": "konkretny powód punktowego odczytu przez rodzica"}
@@ -226,8 +226,18 @@ Opcjonalne `read_coverage` opisuje read-set przekazywany rodzicowi:
 ```
 
 `covered` ma maksymalnie 10 ścieżek, a `follow_up` maksymalnie 8. Rodzic nie
-powinien ponownie czytać ścieżki z `covered`, poza read-before-write, zmianą
-snapshotu, luką w raporcie albo jawnym wymaganiem użytkownika.
+powinien ponownie czytać ścieżki z `covered`, poza punktowym guardem
+`read-before-write`, gdy raport nie obejmuje bieżącej wersji lub zakresu patcha,
+zmianą snapshotu, luką w raporcie albo jawnym wymaganiem użytkownika. Sam status
+`dirty`/`untracked` nie unieważnia ważnego odczytu.
+
+`purpose` jest opcjonalną, deklarowaną etykietą celu odczytu. Jeśli pojawia się
+którekolwiek pole strukturalnego kontekstu, evidence musi zawierać komplet
+`event`, `purpose`, `source` i `read_mode`. Dozwolone wartości `purpose` to
+`discovery`, `read-before-write`, `verification`, `snapshot-refresh` oraz
+`report-gap`. `source` może wskazywać `main`, `parent`, `scout`, `system` albo
+`unknown`, a `read_mode` — `full`, `range` albo `report`. Te pola opisują intencję
+workflow; nie są dowodem aktualności treści pliku ani dowodem braku redundancji.
 
 `claim_type`, `confidence` i co najmniej jeden literalny `anchor` są wymagane w każdym findingu. `observed` oznacza
 bezpośredni fakt z evidence, `structural` relację lub definicję widoczną w kodzie,

--- a/.agents/skills/_shared/references/repository-context-scout-playbook.md
+++ b/.agents/skills/_shared/references/repository-context-scout-playbook.md
@@ -65,6 +65,9 @@ powiązanego z kryterium lub ryzykiem.
    rodzic może potrzebować z konkretnym powodem. Nie powtarzaj odczytów z
    `covered` bez uzasadnienia wynikającego z read-before-write, zmiany snapshotu,
    luki w raporcie albo jawnego wymagania użytkownika.
+   Jeśli zapisujesz cel odczytu, użyj jednej z etykiet `discovery`,
+   `read-before-write`, `verification`, `snapshot-refresh` albo `report-gap`;
+   jest to deklarowany kontekst, nie dowód aktualności pliku.
 
 8. Nie wnioskuj o zawartości pliku z jego nazwy. Claim musi być bezpośrednio
    potwierdzony minimalnym zakresem linii; nie cytuj całego pliku, jeśli kilka

--- a/.agents/skills/_shared/references/runtime-collaboration-guidelines.md
+++ b/.agents/skills/_shared/references/runtime-collaboration-guidelines.md
@@ -66,7 +66,13 @@ Nie jest to konfiguracja konkretnego projektu biznesowego.
 
 ## 3. Zasady bezpiecznej edycji
 - Nie nadpisuj cudzych zmian i nie edytuj plików „w ciemno”.
-- Przed modyfikacją pliku już zmienionego w repo przeczytaj jego aktualną treść i diff.
+- Przed modyfikacją pliku już zmienionego w repo przeczytaj jego aktualną treść i diff,
+  chyba że ważny odczyt obejmuje bieżącą wersję i zakres patcha, a od tego odczytu nie
+  wykryto zmiany.
+- `dirty`/`untracked` opisuje stan repozytorium, a nie samodzielnie nieaktualność wiedzy agenta.
+- Cel odczytu rozróżniaj jako: `discovery`, `read-before-write`, `verification`, `snapshot-refresh` albo `report-gap`.
+- `read-before-write` jest guardem bezpieczeństwa, a nie szerokim krokiem discovery. Jeśli aktualny kontekst obejmuje plik i nie wykryto zmiany od ostatniego odczytu, nie powtarzaj szerokiego odczytu tylko z powodu statusu `dirty`.
+- Etykieta celu odczytu jest deklarowaną telemetrią workflow; nie jest dowodem aktualności treści ani braku redundancji.
 - Nie używaj destrukcyjnych komend git bez wyraźnego polecenia użytkownika.
 - Commity wykonuj tylko po jednoznacznym poleceniu użytkownika i przez dedykowaną procedurę `$git-commit`.
 

--- a/.agents/skills/_shared/scripts/context-scout-hybrid-run.mjs
+++ b/.agents/skills/_shared/scripts/context-scout-hybrid-run.mjs
@@ -190,7 +190,7 @@ function buildTaskPrompt({agent, inputs, reportPath, ledgerPath, mode}) {
         "Use context-scout-report-builder.mjs and the repository contract to produce the report.",
         `Initialize the report ledger exactly at: ${ledgerPath}`,
         discoveryBudget,
-        "Record read_coverage.covered for exact paths read and read_coverage.follow_up for at most 8 parent follow-ups with concrete reasons.",
+        "Record read_coverage.covered for exact paths read and read_coverage.follow_up for at most 8 parent follow-ups with concrete reasons. When a covered path has a meaningful declared purpose, include purpose/source/read_mode from the shared read-purpose enum; these fields are context metadata, not freshness proof.",
         "Every finding must declare claim_type (observed, structural, inferred), confidence (high, medium, low), and anchors containing literal terms present in the cited evidence; never infer a field or behavior from a filename, symbol name, or analogy.",
         primary ? "Default to exactly one compact, parent-ready finding per criterion and keep the complete report near 1000 tokens. Add a second finding only when one criterion spans independent roles that cannot be supported honestly by one claim." : "",
         primary ? "Use at most three minimal evidence ranges per finding. When finding evidence already proves the criterion, keep coverage[].evidence empty instead of duplicating the same ranges; record actual reads only in read_coverage.covered." : "",

--- a/.agents/skills/_shared/scripts/context-scout-report-builder.mjs
+++ b/.agents/skills/_shared/scripts/context-scout-report-builder.mjs
@@ -4,6 +4,7 @@ import {tmpdir} from "node:os";
 import {dirname, isAbsolute, relative, resolve} from "node:path";
 import {validateScoutReport} from "./context-scout-report.mjs";
 import {readCriteriaFile, readCriteriaIds} from "./context-criteria.mjs";
+import {normalizeReadObservation, normalizeReadPath} from "./read-purpose.mjs";
 
 const STATUSES = new Set(["COMPLETE", "INCOMPLETE", "BLOCKED"]);
 const MODES = new Set(["targeted", "cross-layer"]);
@@ -289,12 +290,27 @@ function initLedger(ledgerPath, options) {
 function addCoveredPath(ledgerPath, options) {
     const ledger = readLedger(ledgerPath);
     const evidence = {
-        path: requireValue(options, "path"),
+        path: normalizeReadPath(requireValue(options, "path")),
         line_start: Number(requireValue(options, "line-start")),
         line_end: Number(requireValue(options, "line-end")),
     };
     if (options.locator !== undefined) { evidence.locator = String(options.locator); }
     if (options.relation !== undefined) { evidence.relation = String(options.relation); }
+    if (options.purpose !== undefined || options.event !== undefined || options.source !== undefined || options["read-mode"] !== undefined) {
+        const observation = normalizeReadObservation({
+            event: options.event,
+            purpose: options.purpose,
+            source: options.source ?? "scout",
+            read_mode: options["read-mode"] ?? "range",
+            resource_kind: "path",
+            path: evidence.path,
+        });
+        if (!observation.valid) { throw new Error(observation.errors.join("; ")); }
+        evidence.event = observation.observation.event;
+        evidence.purpose = observation.observation.purpose;
+        evidence.source = observation.observation.source;
+        evidence.read_mode = observation.observation.read_mode;
+    }
     validateEvidenceNow(evidence, ledger.head);
     ledger.read_coverage ??= {covered: [], follow_up: []};
     if (ledger.read_coverage.covered.length >= 10) { throw new Error("read_coverage.covered exceeds 10 paths"); }
@@ -306,7 +322,7 @@ function addCoveredPath(ledgerPath, options) {
 
 function addFollowUpPath(ledgerPath, options) {
     const ledger = readLedger(ledgerPath);
-    const path = requireValue(options, "path");
+    const path = normalizeReadPath(requireValue(options, "path"));
     const reason = requireValue(options, "reason");
     if (path.startsWith("/") || path.includes("..") || path.includes("...")) { throw new Error("follow-up path must be repo-relative without shorthand"); }
     ledger.read_coverage ??= {covered: [], follow_up: []};

--- a/.agents/skills/_shared/scripts/context-scout-report.mjs
+++ b/.agents/skills/_shared/scripts/context-scout-report.mjs
@@ -2,6 +2,7 @@
 import {existsSync, readFileSync} from "node:fs";
 import {execFileSync} from "node:child_process";
 import {readCriteriaFile} from "./context-criteria.mjs";
+import {normalizeReadObservation} from "./read-purpose.mjs";
 
 const STATUSES = new Set(["COMPLETE", "INCOMPLETE", "BLOCKED"]);
 const MODES = new Set(["targeted", "cross-layer"]);
@@ -107,6 +108,28 @@ function validateEvidence(evidence, head, errors, location, evidenceIndex) {
         if (key in evidence && typeof evidence[key] !== "string") {
             errors.push(`${location}.evidence[${evidenceIndex}].${key} must be a string`);
         }
+    }
+    validateReadPurpose(evidence, errors, location, evidenceIndex);
+}
+
+function validateReadPurpose(evidence, errors, location, evidenceIndex) {
+    const purposeKeys = ["event", "purpose", "source", "read_mode"];
+    if (!purposeKeys.some((key) => Object.hasOwn(evidence, key))) { return; }
+    const missing = purposeKeys.filter((key) => !Object.hasOwn(evidence, key));
+    if (missing.length > 0) {
+        errors.push(`${location}.evidence[${evidenceIndex}] read-purpose: structured metadata must include ${purposeKeys.join(", ")}; missing ${missing.join(", ")}`);
+        return;
+    }
+    const result = normalizeReadObservation({
+        event: evidence.event,
+        purpose: evidence.purpose,
+        source: evidence.source ?? "scout",
+        read_mode: evidence.read_mode ?? "range",
+        resource_kind: "path",
+        path: evidence.path,
+    });
+    for (const error of result.errors) {
+        errors.push(`${location}.evidence[${evidenceIndex}] read-purpose: ${error}`);
     }
 }
 

--- a/.agents/skills/_shared/scripts/read-purpose.mjs
+++ b/.agents/skills/_shared/scripts/read-purpose.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+export const READ_PURPOSES = Object.freeze([
+    "discovery",
+    "read-before-write",
+    "verification",
+    "snapshot-refresh",
+    "report-gap",
+]);
+
+export const READ_EVENTS = Object.freeze(["read", "report-reuse"]);
+export const READ_SOURCES = Object.freeze(["main", "parent", "scout", "system", "unknown"]);
+export const READ_MODES = Object.freeze(["full", "range", "report"]);
+
+const PURPOSES = new Set(READ_PURPOSES);
+const EVENTS = new Set(READ_EVENTS);
+const SOURCES = new Set(READ_SOURCES);
+const MODES = new Set(READ_MODES);
+const INTERPRETERS = new Set(["node", "nodejs", "bun", "deno"]);
+const STRUCTURED_OPTIONS = new Set([
+    "event",
+    "purpose",
+    "source",
+    "read-mode",
+    "path",
+    "scope",
+    "delegation-id",
+]);
+
+export function normalizeReadPath(value) {
+    return String(value ?? "").trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/{2,}/g, "/");
+}
+
+export function normalizeReadObservation(input = {}) {
+    const event = input.event ?? "read";
+    const purpose = input.purpose ?? null;
+    const source = input.source ?? "main";
+    const readMode = input.read_mode ?? "full";
+    const resourceKind = input.resource_kind ?? (input.path ? "path" : input.scope ? "scope" : null);
+    const resource = resourceKind === "path"
+        ? normalizeReadPath(input.path ?? input.resource)
+        : String(input.scope ?? input.resource ?? "").trim();
+    const errors = [];
+
+    if (!EVENTS.has(event)) { errors.push(`event must be one of: ${READ_EVENTS.join(", ")}`); }
+    if (purpose !== null && !PURPOSES.has(purpose)) { errors.push(`purpose must be one of: ${READ_PURPOSES.join(", ")}`); }
+    if (!SOURCES.has(source)) { errors.push(`source must be one of: ${READ_SOURCES.join(", ")}`); }
+    if (!MODES.has(readMode)) { errors.push(`read_mode must be one of: ${READ_MODES.join(", ")}`); }
+    if (event === "read" && purpose === null) { errors.push("purpose is required for read events"); }
+    if (event === "read" && !resourceKind) { errors.push("path or scope is required for read events"); }
+    if (event === "report-reuse" && readMode !== "report") { errors.push("report-reuse events must use read_mode=report"); }
+    if (resourceKind !== null && !["path", "scope"].includes(resourceKind)) { errors.push("resource_kind must be path or scope"); }
+    if (resourceKind === "path" && (resource === "" || resource.startsWith("/") || resource.split("/").includes("..") || resource.includes("..."))) {
+        errors.push("path must be a non-empty repo-relative path without traversal or shorthand");
+    }
+    if (resourceKind === "scope" && (resource === "" || resource.length > 200 || /[\r\n]/.test(resource))) {
+        errors.push("scope must be a non-empty single-line identifier up to 200 characters");
+    }
+    if (input.delegation_id !== undefined && (typeof input.delegation_id !== "string" || input.delegation_id.trim() === "")) {
+        errors.push("delegation_id must be a non-empty string when provided");
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        observation: {
+            event,
+            purpose,
+            source,
+            read_mode: readMode,
+            ...(resourceKind ? {resource_kind: resourceKind, resource} : {}),
+            ...(input.delegation_id ? {delegation_id: input.delegation_id.trim()} : {}),
+        },
+    };
+}
+
+export function parseReadEventArgs(argv = []) {
+    const values = {event: "read", source: "main", read_mode: null, purpose: null, path: null, scope: null, delegation_id: undefined};
+    const message = [];
+    const firstArgument = String(argv[0] ?? "");
+    const firstOptionName = firstArgument.startsWith("--") ? firstArgument.slice(2).split(/=(.*)/s, 1)[0] : null;
+    const structured = firstOptionName !== null && STRUCTURED_OPTIONS.has(firstOptionName);
+    const errors = [];
+
+    if (!structured) { return {structured: false, message: argv.map(String), errors: []}; }
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = String(argv[index]);
+        if (!argument.startsWith("--") || argument === "--") {
+            message.push(argument);
+            continue;
+        }
+        const [rawName, inlineValue] = argument.slice(2).split(/=(.*)/s, 2);
+        if (!STRUCTURED_OPTIONS.has(rawName)) {
+            message.push(argument);
+            continue;
+        }
+        const value = inlineValue ?? argv[index + 1];
+        if (value === undefined || (inlineValue === undefined && String(value).startsWith("--"))) {
+            errors.push(`missing value for --${rawName}`);
+            continue;
+        }
+        if (inlineValue === undefined) { index += 1; }
+        if (rawName === "event") { values.event = String(value); }
+        else if (rawName === "purpose") { values.purpose = String(value); }
+        else if (rawName === "source") { values.source = String(value); }
+        else if (rawName === "read-mode") { values.read_mode = String(value); }
+        else if (rawName === "path") {
+            if (values.scope !== null) { errors.push("--path and --scope cannot be combined"); }
+            values.path = String(value);
+        }
+        else if (rawName === "scope") {
+            if (values.path !== null) { errors.push("--path and --scope cannot be combined"); }
+            values.scope = String(value);
+        }
+        else if (rawName === "delegation-id") { values.delegation_id = String(value); }
+    }
+
+    const normalized = normalizeReadObservation({
+        ...values,
+        read_mode: values.read_mode ?? (values.event === "report-reuse" ? "report" : values.path !== null ? "full" : "range"),
+        resource_kind: values.path !== null ? "path" : values.scope !== null ? "scope" : null,
+    });
+    return {structured: true, message, errors: [...errors, ...normalized.errors], observation: normalized.observation};
+}
+
+function tokenizeShellArgs(value) {
+    const tokens = [];
+    let current = "";
+    let quote = null;
+    let escaped = false;
+    for (const character of String(value ?? "")) {
+        if (escaped) { current += character; escaped = false; continue; }
+        if (character === "\\" && quote !== "'") { escaped = true; continue; }
+        if (quote !== null) {
+            if (character === quote) { quote = null; }
+            else { current += character; }
+            continue;
+        }
+        if (character === "'" || character === '"') { quote = character; continue; }
+        if (/\s/.test(character)) {
+            if (current !== "") { tokens.push(current); current = ""; }
+            continue;
+        }
+        current += character;
+    }
+    if (escaped) { current += "\\"; }
+    if (current !== "") { tokens.push(current); }
+    return tokens;
+}
+
+function isReadLogToken(value) {
+    return /(?:^|[\\/])state-readlog\.mjs$/.test(value);
+}
+
+function isInterpreterToken(value) {
+    return INTERPRETERS.has(String(value).split(/[\\/]/).at(-1));
+}
+
+function commandSeparator(value) {
+    return value === ";" || value === "&&" || value === "||" || value === "|";
+}
+
+export function extractReadEventFromCommand(command) {
+    if (typeof command !== "string") { return null; }
+    const tokens = tokenizeShellArgs(command);
+    let commandStart = true;
+    let previous = null;
+    for (let index = 0; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        if (commandSeparator(token)) {
+            commandStart = true;
+            previous = null;
+            continue;
+        }
+        const isExecutable = (commandStart || isInterpreterToken(previous)) && isReadLogToken(token);
+        if (isExecutable) {
+            const args = [];
+            for (const argument of tokens.slice(index + 1)) {
+                if (commandSeparator(argument)) { break; }
+                args.push(argument);
+            }
+            const parsed = parseReadEventArgs(args);
+            return parsed.structured && parsed.errors.length === 0 ? parsed.observation : null;
+        }
+        commandStart = false;
+        previous = token;
+    }
+    return null;
+}
+
+export function formatReadObservation(observation) {
+    const values = [
+        `[read-event] event=${observation.event}`,
+        `purpose=${observation.purpose ?? "none"}`,
+        `source=${observation.source}`,
+        `mode=${observation.read_mode}`,
+    ];
+    if (observation.resource_kind) { values.push(`${observation.resource_kind}=${observation.resource}`); }
+    if (observation.delegation_id) { values.push(`delegation=${observation.delegation_id}`); }
+    return values.join(" ");
+}

--- a/.agents/skills/code-implement/SKILL.md
+++ b/.agents/skills/code-implement/SKILL.md
@@ -23,6 +23,7 @@ shared_files:
     - _shared/scripts/context-scout-hybrid-run.mjs
     - _shared/scripts/context-scout-report-builder.mjs
     - _shared/scripts/context-scout-report.mjs
+    - _shared/scripts/read-purpose.mjs
     - _shared/scripts/env-load.sh
     - _shared/scripts/targeted-check-decision.mjs
 ---
@@ -225,7 +226,7 @@ Minimalny format (utrzymuj spójnie):
   - `- R3 (DONE): Zmiana e-maila profilu działa w Core`
   - `  - Kryteria: Formularz zapisuje e-mail; flash sukcesu; użytkownik pozostaje zalogowany`
   - `  - Dowody: src/Core/UI/Controller/Profile/EmailController.php; sprawdzenie manualne`
-- **Dziennik odczytów**: dopisuj wyłącznie przez `<skill_dir>/scripts/state-readlog.mjs "<msg>"`.
+- **Dziennik odczytów**: dopisuj wyłącznie przez `<skill_dir>/scripts/state-readlog.mjs`; dla odczytów objętych obserwowalnością użyj strukturalnych flag `--purpose`, `--event`, `--source`, `--read-mode` oraz `--path`/`--scope` jako pierwszych argumentów, a zwykły komunikat pozostaje opcjonalny. Legacy free-text zachowuje dowolne późniejsze argumenty.
   - Przykład: `- [2026-01-16T21:20:00+01:00] rg "EntityConnection" -n src; git diff --stat`
 - **Dziennik iteracji**: dopisuj wyłącznie przez `<skill_dir>/scripts/state-log.mjs "<msg>"`.
   - Timestamp zawsze z systemu (`date --iso-8601=seconds`); zero wpisów ręcznych.
@@ -276,9 +277,28 @@ Traktuj plik jako **krytyczny**, jeśli spełnia dowolny warunek:
 ### “Plik już zmieniony w repo” (guard: read-before-write)
 To nie jest “krytyczność” sama w sobie. To guard przeciw nadpisaniu cudzych/ręcznych zmian.
 
-Jeśli plik jest już zmieniony w repo (tracked/untracked) i masz go edytować:
+Jeśli plik jest już zmieniony w repo (tracked/untracked) i nie masz wiarygodnego
+odczytu jego aktualnej wersji dla zakresu patcha:
 - przed edycją **obowiązkowo** przeczytaj diff i bieżącą treść (zakaz edycji “w ciemno”),
 - staraj się robić minimalne patche, żeby nie nadpisać ręcznych zmian użytkownika.
+Jeśli aktualny raport lub wcześniejszy odczyt obejmuje potrzebny zakres i nie
+wykryto zmiany od tego odczytu, reuse kontekstu jest dozwolony; status dirty sam
+w sobie nie wymusza pełnego odczytu.
+
+Status `dirty`/`untracked` nie oznacza automatycznie, że cały plik trzeba ponownie
+odkrywać. Rozróżniaj cel odczytu:
+
+- `discovery` — szerokie rozpoznanie struktury lub zależności;
+- `read-before-write` — punktowy guard przed patchem chroniący cudzą/ręczną zmianę;
+- `verification` — sprawdzenie wyniku albo konkretnego kontraktu;
+- `snapshot-refresh` — odczyt po wykryciu zmiany stanu repozytorium;
+- `report-gap` — uzupełnienie luki w zwalidowanym raporcie.
+
+Jeśli zwalidowany raport obejmuje plik, a od jego odczytu nie wykryto zmiany,
+reuse raportu zastępuje szerokie `discovery`. Przed edycją nadal wykonaj tylko
+guard wymagany przez aktualność pliku, zakres patcha lub jawne wymaganie użytkownika.
+Cel i zakres odczytu loguj strukturalnie przez `state-readlog.mjs` obok zwykłego
+Dziennika odczytów; etykieta jest telemetrią, nie dowodem aktualności treści.
 
 ### “Rejestr wymagań”
 To krótka, numerowana lista wymagań z prompta (R1..Rn), utrzymywana w `STATE_PATH`.
@@ -390,10 +410,12 @@ Opcjonalnie (zalecane): do stworzenia szablonu użyj
    - ustal komendy narzędziowe dla repo (co najmniej `composer`, `console`, `yarn`, `codecept`) wyłącznie przez `resolve_tool_cmd`,
    - `resolve_tool_cmd` traktuj jako jedyne źródło prawdy; aktywne pliki env repo są ładowane automatycznie w resolverze,
    - nie mieszaj wielu wariantów entrypointów w ramach jednego zadania.
-6. Przed zmianą krytycznego pliku **lub** przed edycją pliku, który jest już zmieniony w repo (tracked/untracked):
+6. Przed zmianą krytycznego pliku **lub** przed edycją pliku, którego aktualnej wersji
+   dla zakresu patcha nie obejmuje ważny odczyt:
    - przeczytaj diff (`git diff -- <plik>`) i aktualną treść (relewantne sekcje),
-   - dopiero potem edytuj.
-7. Po każdym realnym odczycie lub komendzie kontekstowej (np. `rg`, `sed`, `git diff`) albo po otrzymaniu raportu helpera lub subagenta dopisz wpis do Dziennika odczytów przez `<skill_dir>/scripts/state-readlog.mjs "<msg>"` (możesz grupować kilka odczytów w jeden wpis).
+   - dopiero potem edytuj. Status tracked/untracked sam nie unieważnia odczytu,
+     jeśli nie wykryto zmiany od jego wykonania.
+7. Po każdym realnym odczycie lub komendzie kontekstowej (np. `rg`, `sed`, `git diff`) albo po otrzymaniu raportu helpera lub subagenta dopisz wpis do Dziennika odczytów przez `<skill_dir>/scripts/state-readlog.mjs` (możesz grupować kilka odczytów w jeden wpis). Jeśli wpis ma być analizowany przez OWE, dodaj zamknięty cel odczytu; `report-reuse` rejestruj jako osobne zdarzenie bez udawania odczytu pliku.
 8. Jeśli w trakcie implementacji wychodzi, że trzeba zmodyfikować plik, który nie wynika wprost z zadania:
    - jeśli to **krytyczny plik**: zatrzymaj się i dopytaj użytkownika, czy taki scope jest akceptowalny,
    - jeśli to **nie jest krytyczny plik**: nie “zasypuj pytaniami” — spróbuj znaleźć rozwiązanie w obrębie ustalonego zakresu; jeśli to niemożliwe, wykonaj minimalną zmianę konieczną technicznie i jawnie zaraportuj to w podsumowaniu.

--- a/.agents/skills/code-implement/scripts/state-clear.mjs
+++ b/.agents/skills/code-implement/scripts/state-clear.mjs
@@ -2,17 +2,24 @@
 import {rmSync} from "node:fs";
 import {pathToFileURL} from "node:url";
 
-import {resolveStatePath, stateExists} from "./state-utils.mjs";
+import {resolveReadEventsPath, resolveStatePath, stateExists} from "./state-utils.mjs";
 
 export function runStateClear({cachePath} = {}) {
     const {absolute: statePath, display} = resolveStatePath(cachePath);
+    const {absolute: readEventsPath, display: readEventsDisplay} = resolveReadEventsPath(cachePath);
+    const statePresent = stateExists(statePath);
+    const readEventsPresent = stateExists(readEventsPath);
 
-    if (!stateExists(statePath)) {
+    if (!statePresent && !readEventsPresent) {
         return {code: 0, stdout: `${display} (missing; nothing to clear)\n`};
     }
 
     rmSync(statePath, {force: true});
-    return {code: 0, stdout: `${display} (cleared)\n`};
+    rmSync(readEventsPath, {force: true});
+    if (statePresent && readEventsPresent) {
+        return {code: 0, stdout: `${display} (cleared; ${readEventsDisplay} cleared)\n`};
+    }
+    return {code: 0, stdout: `${statePresent ? display : readEventsDisplay} (cleared)\n`};
 }
 
 async function main() {

--- a/.agents/skills/code-implement/scripts/state-readlog.mjs
+++ b/.agents/skills/code-implement/scripts/state-readlog.mjs
@@ -2,7 +2,8 @@
 import {existsSync, readFileSync, writeFileSync} from "node:fs";
 import {pathToFileURL} from "node:url";
 
-import {formatIsoSeconds, insertLogLine, resolveStatePath} from "./state-utils.mjs";
+import {formatReadObservation, parseReadEventArgs} from "../../_shared/scripts/read-purpose.mjs";
+import {appendJsonLine, formatIsoSeconds, insertLogLine, resolveReadEventsPath, resolveStatePath} from "./state-utils.mjs";
 
 export function runStateReadLog(argv, {cachePath, now = new Date()} = {}) {
     const {absolute: statePath} = resolveStatePath(cachePath);
@@ -15,8 +16,24 @@ export function runStateReadLog(argv, {cachePath, now = new Date()} = {}) {
         return {code: 1, stderr: "ERROR: missing log message\n"};
     }
 
-    const logLine = `- [${formatIsoSeconds(now)}] ${argv.join(" ")}`;
+    const parsed = parseReadEventArgs(argv);
+    if (parsed.errors.length > 0) {
+        return {code: 1, stderr: `ERROR: ${parsed.errors.join("; ")}\n`};
+    }
+
+    const timestamp = formatIsoSeconds(now);
+    const logMessage = parsed.structured
+        ? [formatReadObservation(parsed.observation), ...parsed.message].join(" ").trim()
+        : argv.join(" ");
+    const logLine = `- [${timestamp}] ${logMessage}`;
     const content = readFileSync(statePath, "utf-8");
+    if (parsed.structured) {
+        appendJsonLine(resolveReadEventsPath(cachePath).absolute, {
+            version: 1,
+            observed_at: timestamp,
+            ...parsed.observation,
+        });
+    }
     writeFileSync(statePath, insertLogLine(content, "### Dziennik odczytów", logLine), "utf-8");
     return {code: 0};
 }

--- a/.agents/skills/code-implement/scripts/state-utils.mjs
+++ b/.agents/skills/code-implement/scripts/state-utils.mjs
@@ -1,4 +1,4 @@
-import {existsSync, mkdirSync, readFileSync, writeFileSync} from "node:fs";
+import {appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync} from "node:fs";
 import {dirname, isAbsolute, join} from "node:path";
 import {fileURLToPath} from "node:url";
 
@@ -19,6 +19,15 @@ export function resolveStatePath(cachePath) {
         ...cacheRoot,
         absolute: join(cacheRoot.absolute, "code-implement/state.md"),
         display: `${cacheRoot.display}/code-implement/state.md`,
+    };
+}
+
+export function resolveReadEventsPath(cachePath) {
+    const cacheRoot = resolveCacheRoot(cachePath);
+    return {
+        ...cacheRoot,
+        absolute: join(cacheRoot.absolute, "code-implement/read-events.jsonl"),
+        display: `${cacheRoot.display}/code-implement/read-events.jsonl`,
     };
 }
 
@@ -58,6 +67,11 @@ export function readText(filePath) {
 export function writeText(filePath, content) {
     ensureParentDir(filePath);
     writeFileSync(filePath, content, "utf-8");
+}
+
+export function appendJsonLine(filePath, value) {
+    ensureParentDir(filePath);
+    appendFileSync(filePath, `${JSON.stringify(value)}\n`, {encoding: "utf-8", flag: "a"});
 }
 
 export function stateExists(statePath) {

--- a/.agents/skills/context-refresh/SKILL.md
+++ b/.agents/skills/context-refresh/SKILL.md
@@ -142,13 +142,13 @@ Cel: zrozumieć, “co jest zmienione w repo” bez konieczności wklejania duż
    - jeśli jest większa: ogranicz się do orientacji (stat/numstat) + pełne diffy tylko dla plików “high-risk” oraz dla obszaru wskazanego w prompt.
 3. Trigger doczytania on-demand (kluczowe):
    Doczytywanie ma być uruchamiane wtedy, gdy “zadanie dotyka” pliku/obszaru, którego nie masz jeszcze wystarczająco dobrze w głowie. Triggerem jest zawsze potrzeba podjęcia decyzji lub wykonania zmiany w danym obszarze.
-   
-   To nie jest “ponowne uruchomienie `$context-refresh`”. To jest punktowe doczytanie tylko tego, co jest potrzebne w danym momencie.
+
+   To nie jest “ponowne uruchomienie `$context-refresh`”. To jest punktowe doczytanie tylko tego, co jest potrzebne w danym momencie. Sam status `dirty` albo `untracked` nie jest dowodem, że poprzedni odczyt jest nieaktualny.
 
    Uruchom doczytanie on-demand, jeśli zachodzi którekolwiek:
    - prompt wprost wymienia ścieżkę pliku (np. `src/.../Foo.php`) → przeczytaj ten plik i jego diff (jeśli ma),
    - prompt wprost wymienia symbol (klasa/metoda/komenda/route) → jeśli Serena dla języka jest dostępna, znajdź definicję przez Serenę; w przeciwnym razie użyj `rg`; następnie przeczytaj definicję + kontekst,
-   - masz zmienić plik, który już jest zmieniony w repo (czyli “modyfikujesz cudze/bieżące zmiany”) → przeczytaj jego diff i aktualną treść przed edycją,
+   - masz zmienić plik, który już jest zmieniony w repo (czyli “modyfikujesz cudze/bieżące zmiany”) i nie masz ważnego odczytu jego aktualnej wersji dla zakresu patcha → przeczytaj jego diff i aktualną treść przed edycją,
    - aktualny moduł ma użyć funkcjonalności z innego modułu → doczytaj dokumentację obu modułów, zaczynając od `MODULE_INDEX_DOC`, jeśli istnieje,
    - masz przygotować treść commita (`$commit-message-write`) → upewnij się, że rozumiesz “co” i “dlaczego” (diff/kluczowe fragmenty),
    - QA/testy zwróciły błąd w pliku, którego nie analizowałeś → doczytaj od razu ten plik i sąsiedni kontekst,
@@ -159,8 +159,9 @@ Cel: zrozumieć, “co jest zmienione w repo” bez konieczności wklejania duż
 4. Procedura doczytania on-demand:
    - Ustal “target” doczytania: plik / moduł / symbol.
    - Jeśli target to plik:
-     - jeśli plik jest zmieniony: przeczytaj `git diff -- <plik>` i aktualną treść pliku (przynajmniej relewantne sekcje),
-     - jeśli plik nie jest zmieniony: przeczytaj aktualną treść pliku (relewantne sekcje).
+     - jeśli plik jest zmieniony i nie ma ważnego odczytu jego aktualnej wersji dla zakresu patcha: przeczytaj `git diff -- <plik>` i aktualną treść pliku (przynajmniej relewantne sekcje),
+     - jeśli plik nie jest zmieniony: przeczytaj aktualną treść pliku (relewantne sekcje),
+     - oznacz odczyt jako `read-before-write`, jeśli chroni patch przed nadpisaniem zmian; jako `snapshot-refresh`, jeśli wynika z wykrytej zmiany snapshotu; w pozostałych przypadkach użyj `discovery`, `verification` albo `report-gap`.
    - Jeśli target to symbol:
      - jeśli Serena dla języka jest dostępna, użyj Sereny najpierw do znalezienia definicji, overview i referencji,
      - jeśli Serena nie jest dostępna, ale działa inna warstwa symboliczna dla języka, użyj jej; w przeciwnym razie użyj `rg`,
@@ -171,7 +172,7 @@ Cel: zrozumieć, “co jest zmienione w repo” bez konieczności wklejania duż
    - Po doczytaniu: wróć do zadania i podejmij decyzję/wykonaj zmianę w oparciu o doczytane informacje.
 
 5. Doczytanie on-demand (krótka zasada wykonawcza):
-   - zanim zmodyfikujesz plik, którego zmian nie rozumiesz (bo np. był już zmieniony przed Twoją pracą), doczytaj jego diff/treść w tym momencie,
+   - zanim zmodyfikujesz plik, którego zmian nie rozumiesz (bo np. był już zmieniony przed Twoją pracą albo zmienił się od ostatniego odczytu), doczytaj jego diff/treść w tym momencie; nie powtarzaj szerokiego discovery, jeśli aktualny raport wystarcza do decyzji,
    - analogicznie: zanim przygotujesz `commit-message.txt`, upewnij się, że rozumiesz „co” i “dlaczego” (w praktyce robi to też `$commit-message-write`).
    - jeśli zadanie jest wyraźnie runtime/debuggingowe i AI Mate jest dostępny, możesz pomocniczo użyć `$dev-mate` do zebrania logów/profilera/DI; nie zastępuje to odczytu kodu ani dokumentacji.
    - jeśli zadanie dotyczy kodu w języku wspieranym przez Serenę, preferuj zawężenie przez Serenę zamiast szerokiego odczytu całych plików; jeśli Serena nie jest dostępna, zastosuj tę samą zasadę do innej warstwy symbolicznej; dla Twig/YAML/docs zwykle pozostań przy `rg` i zwykłym odczycie, a dla SCSS użyj zwykłego patcha tylko wtedy, gdy zmiana jest banalna i lokalna.

--- a/.agents/skills/opencode-workflow-economics/SKILL.md
+++ b/.agents/skills/opencode-workflow-economics/SKILL.md
@@ -111,6 +111,7 @@ node <skill_dir>/scripts/owe.mjs list patterns --view high-cost-read-only --limi
 node <skill_dir>/scripts/owe.mjs show pattern <pattern-id>
 
 node <skill_dir>/scripts/owe.mjs list overlaps --diagnostic strong_repeated_work_signal
+node <skill_dir>/scripts/owe.mjs list overlaps --diagnostic declared_read_context
 node <skill_dir>/scripts/owe.mjs show overlap <delegation-id>
 
 node <skill_dir>/scripts/owe.mjs list roots --sort cost --limit 10
@@ -181,6 +182,7 @@ Use these diagnostic levels:
 - `no_overlap_observed_in_window`;
 - `possible_repeated_work`;
 - `strong_repeated_work_signal`;
+- `declared_read_context`;
 - `mixed_followup`;
 - `insufficient_evidence`.
 
@@ -189,6 +191,11 @@ Interpret them conservatively:
 - exact path/query/symbol/command matches are stronger than similar operation sequences;
 - overlap before the parent's first write is more suggestive of repeated discovery;
 - reads after writes or during verification may be deliberate validation;
+- `declared_read_context` is emitted when a structured read-purpose event is
+  unambiguously correlated with an exact pre-write path match and no stronger
+  repeated-work label wins; the declared context remains attached as evidence
+  when a stronger label is retained. It is workflow metadata, not proof of
+  freshness or non-redundancy;
 - `strong_repeated_work_signal` requires its threshold from ordered pre-write path/query/symbol intersections only;
 - command matches are a separate weaker signal, and post-write exact matches are reported as `mixed_followup` rather than strengthening `strong`;
 - shared operation types, structural families, Jaccard and LCS are bounded descriptive context only; they never raise a repeated-work label;
@@ -212,7 +219,7 @@ For each important subagent or hybrid family consider:
 - child direct and subtree cost;
 - returned output size;
 - fallback frequency and additional fallback cost;
-- distribution of no-overlap, mixed, possible, and strong repeated-work diagnostics;
+- distribution of no-overlap, declared-context, mixed, possible, and strong repeated-work diagnostics;
 - whether the parent proceeds to implementation/verification or repeats discovery.
 
 Do not claim why a fallback occurred solely from sequence. Do not attribute all parent follow-up cost to the child result.

--- a/.agents/skills/opencode-workflow-economics/references/methodology.md
+++ b/.agents/skills/opencode-workflow-economics/references/methodology.md
@@ -57,6 +57,12 @@ before the parent's first write. Command matches remain a separate weaker signal
 and never contribute to `strong_repeated_work_signal`; exact matches after the
 first parent write are reported as `mixed_followup` and do not strengthen strong.
 Matches before the parent's first write are more suggestive of repeated discovery.
+When a structured read-purpose event is unambiguously correlated with an exact
+pre-write path match and no stronger repeated-work evidence wins, classify it as
+`declared_read_context` instead of ordinary repeated work. The declared context
+remains attached to the evidence when a stronger label is retained. It preserves
+exact matches and costs while recording a workflow declaration; it is not proof
+that the read was necessary.
 Jaccard, LCS, shared operation types and structural families remain bounded
 descriptive observations after the Stage 11 ablation; they do not promote a
 delegation to `possible_repeated_work` or `strong_repeated_work_signal`.

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/analysis.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/analysis.mjs
@@ -103,6 +103,7 @@ export function analyzeRoots(parsedRoots, config, pricing, source) {
             unknown_activity_steps: allSteps.filter((step) => step.primary_activity === "unknown").length,
             recurring_pattern_groups: patternAnalysis.summary.recurring_groups,
             strong_repeated_work_signals: overlapAggregates.totals.strong_repeated_work_signal,
+            declared_read_contexts: overlapAggregates.totals.declared_read_contexts,
             possible_repeated_work_signals: overlapAggregates.totals.possible_repeated_work,
             total_usage: aggregateUsage(allSteps),
             total_cost: totalCost,
@@ -685,11 +686,14 @@ function aggregateOverlapAcrossRoots(diagnostics) {
             structural_overlap_only: 0,
             possible_repeated_work: 0,
             strong_repeated_work_signal: 0,
+            declared_read_context: 0,
+            declared_read_contexts: 0,
             mixed_followup: 0,
             insufficient_evidence: 0,
         };
         for (const item of values)
         { result[item.diagnostic] = (result[item.diagnostic] ?? 0) + 1; }
+        result.declared_read_contexts = values.filter((item) => (item.evidence?.declared_read_contexts?.length ?? 0) > 0).length;
         return result;
     };
     return {

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/delegation-overlap.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/delegation-overlap.mjs
@@ -1,7 +1,7 @@
 import { aggregateResourceKeys, operationName } from "./fingerprints.mjs";
 import { aggregateCost } from "./costs.mjs";
 
-export const DELEGATION_OVERLAP_VERSION = "deterministic_evidence_rules_v4_no_structural_classifier";
+export const DELEGATION_OVERLAP_VERSION = "deterministic_evidence_rules_v5_declared_read_context";
 
 const DEFAULTS = {
     max_parent_steps: 8,
@@ -178,6 +178,7 @@ function compareWork(delegation, childTools, childSteps, childSpans, followup, c
     const semanticExactBeforeWrite = countShared(semanticBeforeWrite);
     const commandExactBeforeWrite = sharedBeforeWrite.commands.length;
     const exactAfterWrite = countShared(sharedAfterWrite);
+    const declaredReadContexts = declaredReadContext(beforeWrite, sharedBeforeWrite.paths);
     const strongExact = semanticBeforeWrite.paths.length >= 3
         || semanticBeforeWrite.queries.length >= 2
         || (semanticBeforeWrite.queries.length >= 1 && semanticBeforeWrite.paths.length >= 1)
@@ -190,6 +191,9 @@ function compareWork(delegation, childTools, childSteps, childSpans, followup, c
     }
     else if (strongExact) {
         diagnostic = "strong_repeated_work_signal";
+    }
+    else if (declaredReadContexts.length > 0) {
+        diagnostic = "declared_read_context";
     }
     else if (exactAfterWrite > 0) {
         diagnostic = "mixed_followup";
@@ -209,6 +213,10 @@ function compareWork(delegation, childTools, childSteps, childSpans, followup, c
     }
 
     const limitations = ["Repeated reads may be deliberate verification rather than redundant discovery.", "Raw file contents and raw tool outputs were not compared."];
+    if (declaredReadContexts.length > 0) {
+        limitations.push("Declared read purpose is workflow metadata, not proof of file freshness or absence of redundant work.");
+        limitations.push("Exact resource overlap remains visible; the declared context changes interpretation, not raw counts or costs.");
+    }
     limitations.push("Command matches are a weaker signal and never contribute to strong_repeated_work_signal.");
     if (exactAfterWrite > 0)
     { limitations.push("Exact matches after the parent's first write are reported as mixed_followup and do not strengthen strong_repeated_work_signal."); }
@@ -239,6 +247,7 @@ function compareWork(delegation, childTools, childSteps, childSpans, followup, c
             pre_write_symbol_count: sharedBeforeWrite.symbols.length,
             command_exact_matches_before_first_write: commandExactBeforeWrite,
             exact_resource_matches_after_first_write: exactAfterWrite,
+            declared_read_contexts: declaredReadContexts,
             ordered_exact_matches: orderedExact,
             unordered_exact_matches: unorderedExact,
             overlapping_exact_matches: overlappingExact,
@@ -283,6 +292,8 @@ function countDiagnostics(values) {
         structural_overlap_only: counts.structural_overlap_only ?? 0,
         possible_repeated_work: counts.possible_repeated_work ?? 0,
         strong_repeated_work_signal: counts.strong_repeated_work_signal ?? 0,
+        declared_read_context: counts.declared_read_context ?? 0,
+        declared_read_contexts: values.filter((item) => (item.evidence?.declared_read_contexts?.length ?? 0) > 0).length,
         mixed_followup: counts.mixed_followup ?? 0,
         insufficient_evidence: counts.insufficient_evidence ?? 0,
     };
@@ -385,6 +396,7 @@ function emptyEvidence(childTools, followup) {
         pre_write_symbol_count: 0,
         command_exact_matches_before_first_write: 0,
         exact_resource_matches_after_first_write: 0,
+        declared_read_contexts: [],
         ordered_exact_matches: 0,
         unordered_exact_matches: 0,
         overlapping_exact_matches: 0,
@@ -442,6 +454,26 @@ function toolsAfterFirstWrite(tools) {
     const sorted = tools.slice().sort(compareToolOrder);
     const index = sorted.findIndex((tool) => tool.tool_category === "write");
     return index === -1 ? [] : sorted.slice(index + 1);
+}
+
+function declaredReadContext(tools, sharedPaths) {
+    const shared = new Set(sharedPaths);
+    const contexts = new Map();
+    for (const tool of tools) {
+        const observation = tool.read_observation;
+        if (!observation || observation.event !== "read" || !observation.resource_key || !shared.has(observation.resource_key)) {
+            continue;
+        }
+        const key = `${observation.purpose ?? "unknown"}:${observation.source ?? "unknown"}`;
+        contexts.set(key, {
+            purpose: observation.purpose ?? "unknown",
+            source: observation.source ?? "unknown",
+            read_mode: observation.read_mode ?? "unknown",
+            event: observation.event,
+            matched_path_count: (contexts.get(key)?.matched_path_count ?? 0) + 1,
+        });
+    }
+    return [...contexts.values()].sort((a, b) => a.purpose.localeCompare(b.purpose) || a.source.localeCompare(b.source));
 }
 
 function semanticResourceKeys(keys) {

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/parser.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/parser.mjs
@@ -1,5 +1,6 @@
 import { calculateStepCost } from "./pricing.mjs";
 import { bool, clampText, firstText, integer, nested, record, sha256, utf8Metrics } from "./util.mjs";
+import { extractReadEventFromCommand } from "../../../_shared/scripts/read-purpose.mjs";
 function partType(part) {
     return firstText(part.type) ?? "unknown";
 }
@@ -248,6 +249,24 @@ function parseSession(entry, rootSessionId, config, pricing, mode) {
                 const metadataState = record(state.metadata);
                 const category = toolCategory(config, toolName);
                 const task = category === "delegation";
+                const rawReadObservation = category === "shell"
+                    ? extractReadEventFromCommand(firstText(input.command, input.cmd))
+                    : null;
+                const readObservation = rawReadObservation
+                    ? {
+                        event: rawReadObservation.event,
+                        purpose: rawReadObservation.purpose,
+                        source: rawReadObservation.source,
+                        read_mode: rawReadObservation.read_mode,
+                        resource_kind: rawReadObservation.resource_kind ?? null,
+                        resource_key: rawReadObservation.resource_kind === "path"
+                            ? hashedResource("path", rawReadObservation.resource, normalizePath)
+                            : rawReadObservation.resource_kind === "scope"
+                                ? hashedResource("scope", rawReadObservation.resource, normalizeQuery)
+                                : null,
+                        delegation_id: rawReadObservation.delegation_id ?? null,
+                    }
+                    : null;
                 tools.push({
                     id: `${entry.session.id}:tool:${toolOrdinal}`,
                     session_id: entry.session.id,
@@ -273,6 +292,7 @@ function parseSession(entry, rootSessionId, config, pricing, mode) {
                     background: task ? bool(metadataState.background) : null,
                     semantic_hint: semanticHint(config, mode, category, input),
                     resource_keys: resourceKeys(category, input),
+                    read_observation: readObservation,
                     candidate_child_session_id: task ? firstText(metadataState.sessionId, metadataState.sessionID) : null,
                 });
                 toolOrdinal += 1;

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/report-brief.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/report-brief.mjs
@@ -55,7 +55,7 @@ export function renderAnalysisBrief(bundle, index, options = {}) {
         `- Total API-equivalent cost: ${formatCost(bundle.summary.total_cost)}`,
         `- Delegations: ${bundle.summary.delegations}; configured fallback attempts: ${bundle.summary.fallback_attempts}`,
         `- Recurring structural patterns: ${bundle.summary.recurring_pattern_groups}`,
-        `- Repeated-work diagnostics: strong ${bundle.summary.strong_repeated_work_signals}, possible ${bundle.summary.possible_repeated_work_signals}`,
+        `- Repeated-work diagnostics: strong ${bundle.summary.strong_repeated_work_signals}, declared context ${bundle.summary.declared_read_contexts ?? 0}, possible ${bundle.summary.possible_repeated_work_signals}`,
         "",
     ].join("\n")});
     sections.push({text: ["### Top agents", "", ...bundle.aggregates.by_agent.slice(0, 3).map((row) =>
@@ -102,14 +102,14 @@ export function renderAnalysisBrief(bundle, index, options = {}) {
 
     sections.push({text: ["## Existing subagent diagnostics", "",
         ...(index.subagents.length === 0 ? ["- No valid linked subagent delegations were available."] : index.subagents.slice(0, settings.max_subagents).map((row) =>
-            `- Historical subagent (untrusted) ${formatUntrusted(row.subagent)}: ${row.delegations} delegations; strong ${row.strong_repeated_work_signal}; possible ${row.possible_repeated_work}; mixed ${row.mixed_followup}; no overlap observed ${row.no_overlap_observed_in_window ?? 0}`)), ""].join("\n"), kind: "subagents", record_count: Math.min(index.subagents.length, settings.max_subagents)});
+            `- Historical subagent (untrusted) ${formatUntrusted(row.subagent)}: ${row.delegations} delegations; strong ${row.strong_repeated_work_signal}; declared context ${row.declared_read_contexts ?? 0}; possible ${row.possible_repeated_work}; mixed ${row.mixed_followup}; no overlap observed ${row.no_overlap_observed_in_window ?? 0}`)), ""].join("\n"), kind: "subagents", record_count: Math.min(index.subagents.length, settings.max_subagents)});
 
     const overlaps = selectOverlaps(index, settings.max_overlap_diagnostics);
     for (const item of overlaps) {
         sections.push({text: [
             `## Overlap ${item.delegation_id}`,
             "",
-            `- Historical subagent (untrusted) ${formatUntrusted(item.subagent_name ?? "unknown")}: **${item.diagnostic}**; ordered exact ${item.ordered_exact_matches}; pre-write semantic ${item.semantic_exact_matches_before_first_write ?? "n/a"}; pre-write commands ${item.command_exact_matches_before_first_write ?? "n/a"}; post-write ${item.exact_resource_matches_after_first_write ?? "n/a"}; unordered ${item.unordered_exact_matches}; overlapping ${item.overlapping_exact_matches}; shared structural families ${item.shared_structural_family_count}`,
+            `- Historical subagent (untrusted) ${formatUntrusted(item.subagent_name ?? "unknown")}: **${item.diagnostic}**; declared contexts ${item.declared_read_contexts?.length ?? 0}; ordered exact ${item.ordered_exact_matches}; pre-write semantic ${item.semantic_exact_matches_before_first_write ?? "n/a"}; pre-write commands ${item.command_exact_matches_before_first_write ?? "n/a"}; post-write ${item.exact_resource_matches_after_first_write ?? "n/a"}; unordered ${item.unordered_exact_matches}; overlapping ${item.overlapping_exact_matches}; shared structural families ${item.shared_structural_family_count}`,
             `- Drill-down: \`${command} show overlap ${item.delegation_id}\``,
             "",
         ].join("\n"), kind: "overlaps"});
@@ -170,8 +170,9 @@ function selectPatterns(index, limit) {
 function selectOverlaps(index, limit) {
     const priority = new Map([
         ["strong_repeated_work_signal", 0],
-        ["possible_repeated_work", 1],
-        ["mixed_followup", 2],
+        ["declared_read_context", 1],
+        ["possible_repeated_work", 2],
+        ["mixed_followup", 3],
     ]);
     return index.overlaps
         .filter((item) => priority.has(item.diagnostic))
@@ -189,6 +190,7 @@ function renderProtectedFooter(bundle, command, omitted, settings) {
     lines.push(
         "- Structural patterns are not semantic task classes.",
         "- Parent overlap may represent deliberate verification rather than wasted work.",
+        "- Declared read context is workflow metadata; it changes interpretation only when correlation is unambiguous and does not prove freshness or non-redundancy.",
         "- Strong repeated-work signals require pre-write path/query/symbol evidence; commands are weaker and post-write matches are mixed follow-up only.",
         "- `primary_activity` is an additive navigation label, not the complete purpose of a step.",
         "- Never sum non-additive activity-signal or involved-step cost rows.",

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/report-files.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/report-files.mjs
@@ -130,7 +130,7 @@ export function buildOverlapDetail(bundle, diagnostic) {
         artifact_type: "owe_overlap_detail",
         schema_version: 1,
         generated_at: bundle.generated_at,
-        interpretation_warning: "Overlap is diagnostic evidence. Strong repeated-work signals require ordered exact path/query/symbol intersections before the parent's first write; command matches are weaker, and post-write exact matches are mixed follow-up only. Only ordered post-child evidence contributes to repeated-work labels and follow-up cost; unordered or overlapping reads may be deliberate verification rather than wasted work.",
+        interpretation_warning: "Overlap is diagnostic evidence. Strong repeated-work signals require ordered exact path/query/symbol intersections before the parent's first write; command matches are weaker, and post-write exact matches are mixed follow-up only. Declared read context is workflow metadata, not proof of freshness or non-redundancy. Only ordered post-child evidence contributes to repeated-work labels and follow-up cost; unordered or overlapping reads may be deliberate verification rather than wasted work.",
         diagnostic,
         delegation,
         fallback_economics: fallback,

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/report-index.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/report-index.mjs
@@ -153,6 +153,7 @@ function summarizeOverlap(item, bundle) {
         pre_write_symbol_count: item.evidence?.pre_write_symbol_count ?? 0,
         command_exact_matches_before_first_write: item.evidence?.command_exact_matches_before_first_write ?? 0,
         exact_resource_matches_after_first_write: item.evidence?.exact_resource_matches_after_first_write ?? 0,
+        declared_read_contexts: declaredReadContexts(item),
         ordered_exact_matches: item.evidence?.ordered_exact_matches ?? 0,
         unordered_exact_matches: item.evidence?.unordered_exact_matches ?? 0,
         overlapping_exact_matches: item.evidence?.overlapping_exact_matches ?? 0,
@@ -167,6 +168,10 @@ function summarizeOverlap(item, bundle) {
         parent_exposure_cost: item.parent_exposure?.total_cost ?? null,
         fallback_additional_cost: fallback?.additional_cost ?? null,
     };
+}
+
+function declaredReadContexts(item) {
+    return Array.isArray(item.evidence?.declared_read_contexts) ? item.evidence.declared_read_contexts : [];
 }
 
 function summarizeRoot(root, currency) {
@@ -189,6 +194,7 @@ function summarizeRoot(root, currency) {
 function buildOverlapViews(overlaps) {
     const result = {
         strong_repeated_work_signal: [],
+        declared_read_context: [],
         possible_repeated_work: [],
         mixed_followup: [],
         structural_overlap_only: [],

--- a/.agents/skills/opencode-workflow-economics/scripts/lib/report-query.mjs
+++ b/.agents/skills/opencode-workflow-economics/scripts/lib/report-query.mjs
@@ -113,7 +113,7 @@ function listOverlaps(index, options) {
         throw new Error(`Unknown overlap diagnostic: ${options.diagnostic}. Available: ${Object.keys(index.overlap_views).join(", ")}`);
     }
     if (options.diagnostic) { values = values.filter((item) => item.diagnostic === options.diagnostic); }
-    const priority = new Map([["strong_repeated_work_signal", 0], ["possible_repeated_work", 1], ["mixed_followup", 2], ["no_overlap_observed_in_window", 3], ["structural_overlap_only", 4], ["insufficient_evidence", 5]]);
+    const priority = new Map([["strong_repeated_work_signal", 0], ["declared_read_context", 1], ["possible_repeated_work", 2], ["mixed_followup", 3], ["no_overlap_observed_in_window", 4], ["structural_overlap_only", 5], ["insufficient_evidence", 6]]);
     values.sort((a, b) => (priority.get(a.diagnostic) ?? 99) - (priority.get(b.diagnostic) ?? 99)
         || b.exact_resource_matches_before_first_write - a.exact_resource_matches_before_first_write
         || b.exact_resource_matches - a.exact_resource_matches);
@@ -147,13 +147,13 @@ function renderList(type, values, omitted) {
     if (type === "patterns") {
         for (const item of values) { lines.push(`- ${item.pattern_id}: ${item.collapsed_operation_sequence.join(" → ") || "no tools"}; occurrences ${item.occurrences}; roots ${item.distinct_root_sessions}; total ${formatCost(item.total_cost)}; median ${formatNano(item.median_value_nano, item.total_cost.currency)}; scope ${item.scope}`); }
     } else if (type === "overlaps") {
-        for (const item of values) { lines.push(`- ${item.delegation_id}: historical subagent (untrusted) ${formatUntrusted(item.subagent_name ?? "unknown")}; ${item.diagnostic}; exact ${item.exact_resource_matches}; pre-write semantic ${item.semantic_exact_matches_before_first_write ?? "n/a"}; pre-write commands ${item.command_exact_matches_before_first_write ?? "n/a"}; post-write ${item.exact_resource_matches_after_first_write ?? "n/a"}; root ${item.root_session_id}`); }
+        for (const item of values) { lines.push(`- ${item.delegation_id}: historical subagent (untrusted) ${formatUntrusted(item.subagent_name ?? "unknown")}; ${item.diagnostic}; exact ${item.exact_resource_matches}; declared contexts ${item.declared_read_contexts?.length ?? 0}; pre-write semantic ${item.semantic_exact_matches_before_first_write ?? "n/a"}; pre-write commands ${item.command_exact_matches_before_first_write ?? "n/a"}; post-write ${item.exact_resource_matches_after_first_write ?? "n/a"}; root ${item.root_session_id}`); }
     } else if (type === "roots") {
         for (const item of values) { lines.push(`- ${item.root_session_id}: ${formatCost(item.cost)}; sessions ${item.sessions}; steps ${item.steps}; delegations ${item.delegations}${item.semantic_hint ? `; historical data (untrusted): ${formatUntrusted(item.semantic_hint)}` : ""}`); }
     } else if (type === "models" || type === "activities") {
         for (const item of values) { lines.push(`- ${type === "models" ? "historical model (untrusted) " : "activity "}${type === "models" ? formatUntrusted(item.key) : item.key}: ${formatCost(item.cost)}; ${formatUsage(item.usage)}; ${item.steps} steps; ${item.tools} tools`); }
     } else {
-        for (const item of values) { lines.push(`- historical subagent (untrusted) ${formatUntrusted(item.subagent)}: delegations ${item.delegations}; delegating ${formatCost(item.delegating_step_cost)}; child direct ${formatCost(item.child_direct_cost)}; child subtree ${formatCost(item.child_subtree_cost)}; output ${formatBytes(item.child_output_bytes)} bytes; ordered parent follow-up ${formatCost(item.parent_followup_cost)}; unassigned exposure ${formatCost(item.parent_exposure_cost)}; fallback additional ${formatCost(item.fallback_additional_cost)}; strong ${item.strong_repeated_work_signal ?? 0}; possible ${item.possible_repeated_work ?? 0}; mixed ${item.mixed_followup ?? 0}`); }
+        for (const item of values) { lines.push(`- historical subagent (untrusted) ${formatUntrusted(item.subagent)}: delegations ${item.delegations}; delegating ${formatCost(item.delegating_step_cost)}; child direct ${formatCost(item.child_direct_cost)}; child subtree ${formatCost(item.child_subtree_cost)}; output ${formatBytes(item.child_output_bytes)} bytes; ordered parent follow-up ${formatCost(item.parent_followup_cost)}; unassigned exposure ${formatCost(item.parent_exposure_cost)}; fallback additional ${formatCost(item.fallback_additional_cost)}; strong ${item.strong_repeated_work_signal ?? 0}; declared context ${item.declared_read_contexts ?? 0}; possible ${item.possible_repeated_work ?? 0}; mixed ${item.mixed_followup ?? 0}`); }
     }
     lines.push("", `Omitted records: ${omitted}`);
     return `${lines.join("\n")}\n`;

--- a/tests/skills/_shared/context-scout-report-builder.test.mjs
+++ b/tests/skills/_shared/context-scout-report-builder.test.mjs
@@ -62,7 +62,7 @@ describe("context scout report builder", () => {
             "add-covered-path",
             ledger,
             "--path",
-            "AGENTS.md",
+            "./AGENTS.md",
             "--line-start",
             "1",
             "--line-end",
@@ -95,6 +95,36 @@ describe("context scout report builder", () => {
         const value = JSON.parse(fs.readFileSync(ledger, "utf8"));
         expect(value.read_coverage.covered).toHaveLength(1);
         expect(value.read_coverage.follow_up).toEqual([{path: "README.md", reason: "parent needs implementation-level read"}]);
+    });
+
+    it("accepts a declared read purpose on covered evidence", () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "context-scout-builder-test-"));
+        const ledger = path.join(dir, "ledger.json");
+        const criteria = path.join(dir, "criteria.json");
+        fs.writeFileSync(criteria, JSON.stringify({criteria: [{id: "C1", description: "Map the flow."}]}));
+        const init = spawnSync(process.execPath, [BUILDER, "init", ledger, "--head", "HEAD", "--criteria", criteria, "--mode", "targeted"], {
+            cwd: ROOT,
+            encoding: "utf8",
+        });
+        expect(init.status, init.stderr).toBe(0);
+        const covered = spawnSync(process.execPath, [
+            BUILDER,
+            "add-covered-path",
+            ledger,
+            "--path", "AGENTS.md",
+            "--line-start", "1",
+            "--line-end", "1",
+            "--purpose", "discovery",
+            "--source", "scout",
+            "--read-mode", "range",
+        ], {cwd: ROOT, encoding: "utf8"});
+        expect(covered.status, covered.stderr).toBe(0);
+        expect(JSON.parse(fs.readFileSync(ledger, "utf8")).read_coverage.covered[0]).toMatchObject({
+            path: "AGENTS.md",
+            purpose: "discovery",
+            source: "scout",
+            read_mode: "range",
+        });
     });
 
     it("accepts a complete report in one batch and renders it from the ledger", () => {

--- a/tests/skills/_shared/context-scout-report.test.mjs
+++ b/tests/skills/_shared/context-scout-report.test.mjs
@@ -89,4 +89,15 @@ describe("context scout report evidence discipline", () => {
         expect(strict.valid).toBe(false);
         expect(strict.errors.join("\n")).toMatch(/forbidden negative or exhaustive claim/);
     });
+
+    it("requires complete structured read metadata once read purpose is declared", () => {
+        const evidence = {path: "AGENTS.md", line_start: 1, line_end: 1, purpose: "discovery"};
+        const result = validateScoutReport(report({
+            findings: [{...report().findings[0], evidence: [evidence]}],
+            coverage: [{criterion_id: "C1", status: "covered", evidence: [evidence]}],
+        }), {criteria: new Set(["C1"])});
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.join("\n")).toMatch(/structured metadata must include/);
+    });
 });

--- a/tests/skills/_shared/read-purpose-contract.test.mjs
+++ b/tests/skills/_shared/read-purpose-contract.test.mjs
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import {describe, expect, it} from "vitest";
+
+import {normalizeReadObservation, READ_PURPOSES} from "../../../.agents/skills/_shared/scripts/read-purpose.mjs";
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../../");
+
+function read(relativePath) {
+    return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+describe("read-purpose workflow contract", () => {
+    it("publishes one shared vocabulary across the safety and context skills", () => {
+        const documents = [
+            read(".agents/skills/_shared/references/runtime-collaboration-guidelines.md"),
+            read(".agents/skills/code-implement/SKILL.md"),
+            read(".agents/skills/context-refresh/SKILL.md"),
+            read(".agents/skills/_shared/references/context-subagent-contract.md"),
+        ].join("\n");
+
+        for (const purpose of ["discovery", "read-before-write", "verification", "snapshot-refresh", "report-gap"]) {
+            expect(documents).toContain(purpose);
+        }
+        expect(documents).toContain("dirty`/`untracked");
+        expect(READ_PURPOSES).toEqual(["discovery", "read-before-write", "verification", "snapshot-refresh", "report-gap"]);
+        expect(normalizeReadObservation({purpose: "not-a-purpose", path: "src/example.mjs"}).valid).toBe(false);
+    });
+
+    it("keeps the structured event implementation discoverable from code-implement", () => {
+        const skill = read(".agents/skills/code-implement/SKILL.md");
+        expect(skill).toContain("_shared/scripts/read-purpose.mjs");
+        expect(skill).toContain("--purpose");
+        expect(skill).toContain("report-reuse");
+    });
+});

--- a/tests/skills/_shared/read-purpose.test.mjs
+++ b/tests/skills/_shared/read-purpose.test.mjs
@@ -1,0 +1,66 @@
+import {describe, expect, it} from "vitest";
+
+import {
+    extractReadEventFromCommand,
+    normalizeReadObservation,
+    parseReadEventArgs,
+} from "../../../.agents/skills/_shared/scripts/read-purpose.mjs";
+
+describe("read-purpose contract", () => {
+    it("normalizes a full path read event", () => {
+        expect(normalizeReadObservation({
+            purpose: "read-before-write",
+            source: "parent",
+            read_mode: "full",
+            resource_kind: "path",
+            path: "./src\\Example.mjs",
+        })).toEqual({
+            valid: true,
+            errors: [],
+            observation: {
+                event: "read",
+                purpose: "read-before-write",
+                source: "parent",
+                read_mode: "full",
+                resource_kind: "path",
+                resource: "src/Example.mjs",
+            },
+        });
+    });
+
+    it("keeps legacy text arguments unstructured", () => {
+        expect(parseReadEventArgs(["git", "diff", "--stat"])).toEqual({
+            structured: false,
+            message: ["git", "diff", "--stat"],
+            errors: [],
+        });
+        expect(parseReadEventArgs(["rg", "--path", "foo.txt"])).toEqual({
+            structured: false,
+            message: ["rg", "--path", "foo.txt"],
+            errors: [],
+        });
+    });
+
+    it("extracts structured state-readlog metadata from a shell command", () => {
+        expect(extractReadEventFromCommand(
+            "node .agents/skills/code-implement/scripts/state-readlog.mjs --purpose verification --source scout --path tests/example.mjs",
+        )).toMatchObject({
+            event: "read",
+            purpose: "verification",
+            source: "scout",
+            read_mode: "full",
+            resource_kind: "path",
+            resource: "tests/example.mjs",
+        });
+    });
+
+    it("does not treat a quoted or non-executable mention as a state-readlog invocation", () => {
+        expect(extractReadEventFromCommand("echo 'run state-readlog.mjs --purpose verification --path foo.txt'")).toBeNull();
+        expect(extractReadEventFromCommand("echo state-readlog.mjs --purpose verification --path foo.txt")).toBeNull();
+    });
+
+    it("rejects path traversal and unqualified read events", () => {
+        expect(normalizeReadObservation({purpose: "discovery", path: "../secrets.txt"}).valid).toBe(false);
+        expect(normalizeReadObservation({purpose: "discovery"}).errors).toContain("path or scope is required for read events");
+    });
+});

--- a/tests/skills/code-implement/state-scripts.test.mjs
+++ b/tests/skills/code-implement/state-scripts.test.mjs
@@ -1,4 +1,4 @@
-import {mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
+import {existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {describe, expect, it} from "vitest";
@@ -7,7 +7,7 @@ import {runStateClear} from "../../../.agents/skills/code-implement/scripts/stat
 import {runStateInit} from "../../../.agents/skills/code-implement/scripts/state-init.mjs";
 import {runStateLog} from "../../../.agents/skills/code-implement/scripts/state-log.mjs";
 import {runStateReadLog} from "../../../.agents/skills/code-implement/scripts/state-readlog.mjs";
-import {formatIsoSeconds, formatLocalDate, formatLocalTime, resolveStatePath} from "../../../.agents/skills/code-implement/scripts/state-utils.mjs";
+import {formatIsoSeconds, formatLocalDate, formatLocalTime, resolveReadEventsPath, resolveStatePath} from "../../../.agents/skills/code-implement/scripts/state-utils.mjs";
 
 describe("code-implement state scripts", () => {
     it("initializes a state file once and keeps it stable on rerun", () => {
@@ -80,14 +80,140 @@ describe("code-implement state scripts", () => {
             });
 
             writeFileSync(statePath, "content\n", "utf-8");
+            const readEventsPath = resolveReadEventsPath(cachePath).absolute;
+            writeFileSync(readEventsPath, "{\"version\":1}\n", "utf-8");
             expect(runStateClear({cachePath})).toEqual({
                 code: 0,
-                stdout: `${resolveStatePath(cachePath).display} (cleared)\n`,
+                stdout: `${resolveStatePath(cachePath).display} (cleared; ${resolveReadEventsPath(cachePath).display} cleared)\n`,
             });
+            expect(existsSync(readEventsPath)).toBe(false);
             expect(runStateClear({cachePath})).toEqual({
                 code: 0,
                 stdout: `${resolveStatePath(cachePath).display} (missing; nothing to clear)\n`,
             });
+        } finally {
+            rmSync(tempRoot, {force: true, recursive: true});
+        }
+    });
+
+    it("writes a validated structured read event without raw message content in the sidecar", () => {
+        const tempRoot = mkdtempSync(path.join(os.tmpdir(), "code-implement-state-test-"));
+        try {
+            const cachePath = path.join(tempRoot, "cache");
+            const statePath = resolveStatePath(cachePath).absolute;
+            mkdirSync(path.dirname(statePath), {recursive: true});
+            writeFileSync(statePath, "### Dziennik odczytów\n\n### Dziennik iteracji\n", "utf-8");
+            const now = new Date("2026-07-02T10:14:15.000Z");
+
+            expect(runStateReadLog([
+                "--purpose", "read-before-write",
+                "--source", "parent",
+                "--read-mode", "full",
+                "--path", "src/example.mjs",
+                "diff", "and", "current", "content",
+            ], {cachePath, now})).toEqual({code: 0});
+
+            const state = readFileSync(statePath, "utf-8");
+            expect(state).toContain("[read-event] event=read purpose=read-before-write source=parent mode=full path=src/example.mjs");
+            expect(state).toContain("diff and current content");
+
+            const eventsPath = resolveReadEventsPath(cachePath).absolute;
+            expect(existsSync(eventsPath)).toBe(true);
+            const event = JSON.parse(readFileSync(eventsPath, "utf-8"));
+            expect(event).toMatchObject({
+                version: 1,
+                observed_at: formatIsoSeconds(now),
+                event: "read",
+                purpose: "read-before-write",
+                source: "parent",
+                read_mode: "full",
+                resource_kind: "path",
+                resource: "src/example.mjs",
+            });
+            expect(event).not.toHaveProperty("message");
+        } finally {
+            rmSync(tempRoot, {force: true, recursive: true});
+        }
+    });
+
+    it("reports an orphaned read-events sidecar accurately when clearing state", () => {
+        const tempRoot = mkdtempSync(path.join(os.tmpdir(), "code-implement-state-test-"));
+        try {
+            const cachePath = path.join(tempRoot, "cache");
+            const readEventsPath = resolveReadEventsPath(cachePath).absolute;
+            mkdirSync(path.dirname(readEventsPath), {recursive: true});
+            writeFileSync(readEventsPath, "{\"version\":1}\n", "utf-8");
+
+            expect(runStateClear({cachePath})).toEqual({
+                code: 0,
+                stdout: `${resolveReadEventsPath(cachePath).display} (cleared)\n`,
+            });
+        } finally {
+            rmSync(tempRoot, {force: true, recursive: true});
+        }
+    });
+
+    it("rejects unknown structured read purposes without changing state or sidecar", () => {
+        const tempRoot = mkdtempSync(path.join(os.tmpdir(), "code-implement-state-test-"));
+        try {
+            const cachePath = path.join(tempRoot, "cache");
+            const statePath = resolveStatePath(cachePath).absolute;
+            mkdirSync(path.dirname(statePath), {recursive: true});
+            writeFileSync(statePath, "### Dziennik odczytów\n", "utf-8");
+
+            expect(runStateReadLog([
+                "--purpose", "unknown-purpose",
+                "--path", "src/example.mjs",
+            ], {cachePath})).toMatchObject({code: 1});
+            expect(readFileSync(statePath, "utf-8")).toBe("### Dziennik odczytów\n");
+            expect(existsSync(resolveReadEventsPath(cachePath).absolute)).toBe(false);
+        } finally {
+            rmSync(tempRoot, {force: true, recursive: true});
+        }
+    });
+
+    it("does not update state.md when the structured sidecar cannot be appended", () => {
+        const tempRoot = mkdtempSync(path.join(os.tmpdir(), "code-implement-state-test-"));
+        try {
+            const cachePath = path.join(tempRoot, "cache");
+            const statePath = resolveStatePath(cachePath).absolute;
+            mkdirSync(path.dirname(statePath), {recursive: true});
+            writeFileSync(statePath, "### Dziennik odczytów\n", "utf-8");
+            mkdirSync(resolveReadEventsPath(cachePath).absolute);
+            const before = readFileSync(statePath, "utf-8");
+
+            expect(() => runStateReadLog([
+                "--purpose", "verification",
+                "--path", "src/example.mjs",
+            ], {cachePath})).toThrow();
+            expect(readFileSync(statePath, "utf-8")).toBe(before);
+        } finally {
+            rmSync(tempRoot, {force: true, recursive: true});
+        }
+    });
+
+    it("records report reuse as an event distinct from a file read", () => {
+        const tempRoot = mkdtempSync(path.join(os.tmpdir(), "code-implement-state-test-"));
+        try {
+            const cachePath = path.join(tempRoot, "cache");
+            const statePath = resolveStatePath(cachePath).absolute;
+            mkdirSync(path.dirname(statePath), {recursive: true});
+            writeFileSync(statePath, "### Dziennik odczytów\n", "utf-8");
+
+            expect(runStateReadLog([
+                "--event", "report-reuse",
+                "--scope", "scout-report-42",
+                "reuse", "validated", "report",
+            ], {cachePath})).toEqual({code: 0});
+
+            const event = JSON.parse(readFileSync(resolveReadEventsPath(cachePath).absolute, "utf-8"));
+            expect(event).toMatchObject({
+                event: "report-reuse",
+                read_mode: "report",
+                resource_kind: "scope",
+                resource: "scout-report-42",
+            });
+            expect(event.purpose).toBeNull();
         } finally {
             rmSync(tempRoot, {force: true, recursive: true});
         }

--- a/tests/skills/opencode-workflow-economics/methodology.test.mjs
+++ b/tests/skills/opencode-workflow-economics/methodology.test.mjs
@@ -18,7 +18,7 @@ describe("OWE methodology manifest", () => {
             fingerprint_version: "operation_fingerprint_v2",
             pattern_grouping_version: "exact_fingerprint_identity_v2",
             representative_sampling_version: "representative_sampling_v2",
-            overlap_version: "deterministic_evidence_rules_v4_no_structural_classifier",
+            overlap_version: "deterministic_evidence_rules_v5_declared_read_context",
             effective_thresholds: {
                 fingerprints: {step_count_maxima: [1, 4, 8]},
                 patterns: {min_occurrences: 2},

--- a/tests/skills/opencode-workflow-economics/read-context.test.mjs
+++ b/tests/skills/opencode-workflow-economics/read-context.test.mjs
@@ -1,0 +1,81 @@
+import {describe, expect, it} from "vitest";
+
+import {analyzeCorpusCase, CORPUS_CASES} from "../../../.agents/skills/opencode-workflow-economics/corpus/cases.mjs";
+import {buildReportIndex} from "../../../.agents/skills/opencode-workflow-economics/scripts/lib/report-index.mjs";
+
+describe("OWE declared read context", () => {
+    it("retains a stronger repeated-work signal while preserving declared context", () => {
+        const definition = structuredClone(CORPUS_CASES[1]);
+        const root = definition.roots.find((item) => item.root_session_id === "overlap-strong");
+        const followupStep = root.tree[0].messages[2];
+        const finish = followupStep.parts.pop();
+        followupStep.parts.push({
+            type: "tool",
+            tool: "shell",
+            state: {
+                status: "completed",
+                input: {
+                    command: "node .agents/skills/code-implement/scripts/state-readlog.mjs --purpose read-before-write --source parent --path src/Order.mjs",
+                },
+                output: "ok",
+            },
+        }, finish);
+
+        const result = analyzeCorpusCase({
+            ...definition,
+            roots: [root],
+        });
+        const diagnostic = result.delegation_overlap_diagnostics[0];
+
+        expect(diagnostic.diagnostic).toBe("strong_repeated_work_signal");
+        expect(diagnostic.evidence.declared_read_contexts).toEqual([
+            expect.objectContaining({purpose: "read-before-write", source: "parent", event: "read"}),
+        ]);
+        expect(diagnostic.evidence.exact_resource_matches_before_first_write).toBe(2);
+        expect(diagnostic.limitations.join(" ")).toContain("workflow metadata");
+        expect(result.summary.strong_repeated_work_signals).toBe(1);
+        expect(result.summary.declared_read_contexts).toBe(1);
+        expect(buildReportIndex(result).overlap_views.declared_read_context).toEqual([]);
+    });
+
+    it("keeps untagged exact overlap conservative", () => {
+        const result = analyzeCorpusCase({
+            ...CORPUS_CASES[1],
+            roots: [CORPUS_CASES[1].roots.find((item) => item.root_session_id === "overlap-strong")],
+        });
+
+        expect(result.delegation_overlap_diagnostics[0].diagnostic).toBe("strong_repeated_work_signal");
+        expect(result.summary.declared_read_contexts).toBe(0);
+    });
+
+    it("uses declared context when no stronger repeated-work signal exists", () => {
+        const definition = structuredClone(CORPUS_CASES[1]);
+        const root = definition.roots.find((item) => item.root_session_id === "overlap-strong");
+        const parentStep = root.tree[0].messages[2];
+        const parentTool = parentStep.parts.find((part) => part.type === "tool");
+        parentTool.tool = "read";
+        parentTool.state.input = {filePath: "src/Order.mjs"};
+        const finish = parentStep.parts.pop();
+        parentStep.parts.push({
+            type: "tool",
+            tool: "shell",
+            state: {
+                status: "completed",
+                input: {
+                    command: "node .agents/skills/code-implement/scripts/state-readlog.mjs --purpose read-before-write --source parent --path src/Order.mjs",
+                },
+                output: "ok",
+            },
+        }, finish);
+        const childTool = root.tree[1].messages[1].parts.find((part) => part.type === "tool");
+        childTool.tool = "read";
+        childTool.state.input = {filePath: "src/Order.mjs"};
+
+        const result = analyzeCorpusCase({...definition, roots: [root]});
+        const diagnostic = result.delegation_overlap_diagnostics[0];
+
+        expect(diagnostic.diagnostic).toBe("declared_read_context");
+        expect(diagnostic.evidence.declared_read_contexts).toHaveLength(1);
+        expect(buildReportIndex(result).overlap_views.declared_read_context).toEqual([diagnostic.delegation_id]);
+    });
+});


### PR DESCRIPTION
## Zmiany ogólne
- Ujednolicono reguły read-before-write oraz semantykę celów odczytu w skillach i kontraktach repository-context.
- Dodano walidowane zdarzenia celu odczytu, sidecar JSONL oraz spójne czyszczenie lokalnego stanu.
- Rozszerzono raportowanie i testy o deklarowany kontekst odczytu, zachowując surowe pomiary kosztów i konserwatywną klasyfikację.

## Zmiany API poleceń CLI
- Rozszerzono state-readlog o strukturalne flagi celu, źródła, trybu i zasobu z zachowaniem legacy free-text.