### PR TITLE
feat: rozszerzono kontrakt task-plan o drafty i decyzje

### DIFF
--- a/.agents/skills/task-plan/SKILL.md
+++ b/.agents/skills/task-plan/SKILL.md
@@ -95,6 +95,7 @@ Każdy plan przechodzi przez następujące etapy w tej kolejności:
 
 ```text
 source/intake
+  → initial draft zapisany w docs/draft
   → Plan v1
   → review krytyczny i findings
   → rewizja planu oraz kolejne review (maks. 3 iteracje)
@@ -123,6 +124,30 @@ Wykonano:
 Następny dozwolony krok:
 Niedozwolone jeszcze:
 ```
+
+### Draft jako żywy artefakt workflow
+
+Po przejściu bramki intencji task-plan najpierw tworzy atomowo główny draft w
+`docs/draft/`, a dopiero potem pobiera źródło lub wykonuje rozpoznanie
+repozytorium. Draft jest niezależnym artefaktem roboczym: może przechowywać
+pochodzenie i referencje do `source_data`, ale nie jest źródłem wejściowym ani
+jego kopią podlegającą nadpisaniu.
+
+Obowiązuje kolejność:
+
+1. ustal stabilną tożsamość wejścia i ścieżkę draftu;
+2. zapisz minimalny, poprawny szkic Markdown w `docs/draft/`;
+3. po każdym istotnym kroku analizy aktualizuj ten sam plik atomowo;
+4. przed każdą serią pytań zapisz bieżącą wersję draftu i pokaż użytkownikowi
+   jej ścieżkę oraz wersję;
+5. po odpowiedzi użytkownika najpierw zaktualizuj draft, rozstrzygnięcia,
+   zależności i strategię sesji, a dopiero potem zadawaj kolejne pytania;
+6. po błędzie źródła lub zapisu zachowaj ostatni poprawny draft albo utwórz
+   częściowy draft z miejscem zatrzymania. Końcowy artefakt task-plan jest
+   zawsze plikiem `.md` pod `docs/draft/`.
+
+Nie wolno emitować pytania, którego aktualna treść, kontekst i opcje nie są już
+zmaterializowane w draftcie.
 
 ## Trigger i bramka intencji
 
@@ -458,6 +483,48 @@ workflow task-plan. Dodatkowa reprezentacja w innym bounded context może być
 uzasadniona tylko przez powyższy kontrakt cross-context, a nie przez samą nazwę
 albo podobieństwo struktury.
 
+## Strategia sesji
+
+Każdy plan zawiera strategię sesji. Strategia jest rekomendacją organizacji
+realizacji, a nie automatycznym wykonaniem ani drugim workflow. Musi określać:
+
+- tryb: `single-session`, `staged` albo `hybrid`;
+- uzasadnienie podziału lub braku podziału;
+- etapy `S1`, `S2`, ... z tytułem, celem, przypisanymi WP, zależnościami,
+  granicą sesji oraz warunkami wejścia i wyjścia;
+- rekomendację, czy kolejny etap realizować w tej samej, czy w oddzielnej
+  sesji.
+
+Nie obowiązuje mechaniczna zasada „jeden WP = jedna sesja”. Pakiety można
+łączyć, gdy mają wspólną semantykę, kryteria lub cykl weryfikacji. Oddzielną
+sesję rekomenduj, gdy występuje silna zależność, duże ryzyko, osobny bounded
+context albo potrzeba niezależnego review.
+
+Minimalny model danych strategii:
+
+```yaml
+session_strategy:
+  mode: staged
+  rationale: "WP1 stabilizuje kontrakt przed WP2."
+  stages:
+    - id: S1
+      title: "Kontrakt"
+      rationale: "Ustalić wspólny kontrakt przed runtime."
+      work_package_ids: [WP1]
+      dependencies: []
+      session_boundary: separate-session
+      entry_criteria: ["Źródło i zakres są potwierdzone."]
+      exit_criteria: ["WP1 ma jawne kryteria i decyzję."]
+  dependencies: ["WP2 depends_on WP1"]
+  session_boundary_recommendation: "WP2 rozpocząć w nowej sesji."
+  entry_criteria: ["Przeszła bramka intencji."]
+  exit_criteria: ["Każdy etap ma terminalny wynik."]
+```
+
+Strategię aktualizuj po zmianie zakresu lub decyzji użytkownika. Jeżeli decyzja
+zmienia grupowanie WP albo granice sesji, propaguj ją także do tej sekcji i
+zapisz w historii rewizji.
+
 ## Work packages
 
 Jeden materiał źródłowy tworzy jeden główny plan, który może zawierać wiele
@@ -560,13 +627,13 @@ planie nadrzędnym zapisuje link do niego. Nazwa i minimalne metadane są
 deterministyczne:
 
 ```text
-docs/draft/issue-<id>-wp-<wpid>-<package-slug>-plan.md
+docs/draft/issue-<id>-wp-<wpid>-plan.md
 ```
 
 ```yaml
 source_kind: derived-work-package
 parent_issue: 123
-parent_draft: issue-123-main-title-plan.md
+parent_draft: issue-123-plan.md
 work_package_id: WP2
 plan_status: needs-clarification
 ```
@@ -574,7 +641,7 @@ plan_status: needs-clarification
 Wpis w planie nadrzędnym wskazuje wynik operacji, np.:
 
 ```md
-WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-import-plan.md)
+WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-plan.md)
 ```
 
 Pakiet wydzielony nie jest automatycznie zaakceptowany; jego draft przechodzi
@@ -892,19 +959,39 @@ Każde pytanie jest strukturalnym rekordem z unikalnym, stabilnym ID:
 ```text
 scope_questions:
   - id: SQ1
-    prompt: "Czy async ma być opt-in, czy domyślny dla wszystkich POST-ów grida?"
+    prompt: "Kontrakt wszystkich POST-ów grida musi określić tryb async. Czy async ma być opt-in, czy domyślny?"
+    context: "Decyzja zmienia zachowanie wszystkich pakietów runtime."
     blocking: true
     resolved: false
     impact: "Zmienia kontrakt wszystkich pakietów runtime."
-    decision_needed: "Wybrać opt-in albo default async."
+    decision_needed: "Wybrać jedną z dwóch opcji i zaakceptować jej konsekwencje."
+    options:
+      - id: opt-in
+        label: "Async tylko po jawnym włączeniu"
+        description: "Dotychczasowe wywołania pozostają synchroniczne."
+        consequence: "Minimalizuje ryzyko kompatybilności, ale wymaga jawnego wdrożenia async dla nowych przypadków."
+      - id: default
+        label: "Async domyślnie"
+        description: "Nowe wywołania korzystają z async bez dodatkowej konfiguracji."
+        consequence: "Upraszcza adopcję, ale zmienia zachowanie istniejących klientów i rozszerza zakres testów."
 
 packages[].questions:
   - id: WP2-Q1
-    prompt: "Jakie kody HTTP i envelope JSON obowiązują dla błędów domenowych?"
+    prompt: "WP2 musi obsłużyć błędy domenowe, uprawnienia i CSRF. Jakie kody HTTP oraz envelope JSON mają obowiązywać?"
+    context: "Odpowiedź jest częścią publicznego kontraktu i wpływa na kryteria akceptacji WP2."
     blocking: true
     resolved: false
     impact: "Definiuje kryteria akceptacji WP2."
-    decision_needed: "Ustalić kody HTTP i format envelope."
+    decision_needed: "Wybrać wariant kontraktu i wskazać ewentualne wyjątki."
+    options:
+      - id: existing
+        label: "Zachować istniejący kontrakt"
+        description: "Użyć obecnych kodów i envelope JSON."
+        consequence: "Ogranicza zakres oraz ryzyko migracji, ale utrwala obecne ograniczenia kontraktu."
+      - id: redesign
+        label: "Wprowadzić nowy kontrakt"
+        description: "Ujednolicić kody i envelope dla wszystkich błędów."
+        consequence: "Daje spójniejszy interfejs, ale wymaga zmian klientów, testów i dokumentacji."
 ```
 
 ID mają format `SQ<number>` dla pytań zakresowych oraz
@@ -912,6 +999,11 @@ ID mają format `SQ<number>` dla pytań zakresowych oraz
 `prompt`, `blocking`, `resolved`, `impact` i `decision_needed`. Pytania muszą
 być osobnymi rekordami — nie wolno scalać kilku pytań w jeden akapit ani używać
 formatu `**Pytania:** pytanie 1? pytanie 2?`.
+`prompt` powinien być zrozumiały bez otwierania innych sekcji, a opcjonalny
+`context` ma wyjaśniać granicę decyzji. Jeżeli pytanie ma opcje, każda opcja
+zawiera `id`, `label` lub `description` oraz `consequence`/`tradeoff` w kilku
+zdaniach. Renderer pokazuje te informacje, a użytkownik może odpowiedzieć samym
+identyfikatorem opcji.
 Jeżeli `resolved: true`, rekord musi dodatkowo zachować `answer`,
 `decision_source` i `decided_at`; formatter pokazuje tę odpowiedź przy pytaniu.
 Pytanie nierozstrzygnięte nie może zawierać częściowej odpowiedzi.
@@ -932,6 +1024,10 @@ renderuje sekcję w następującym układzie:
 - **SQ1 [BLOCKING]** Czy async ma być opt-in, czy domyślny dla wszystkich POST-ów grida?
   - Wpływ: zmienia kontrakt wszystkich pakietów runtime.
   - Wymagana decyzja: wybrać `opt-in` albo `default async`.
+  - Kontekst: decyzja zmienia zachowanie wszystkich pakietów runtime.
+  - Opcje:
+    - `opt-in` — async tylko po jawnym włączeniu. Konsekwencja: mniejsza zmiana kompatybilności, ale większy koszt adopcji.
+    - `default` — async domyślnie. Konsekwencja: prostsza adopcja, ale szersze testy istniejących klientów.
   - Status: `open`
 
 ### WP2 — Runtime TypeScript/Stimulus
@@ -944,6 +1040,10 @@ renderuje sekcję w następującym układzie:
 - **WP2-Q1 [BLOCKING]** Jakie kody HTTP i envelope JSON obowiązują dla błędów domenowych?
   - Wpływ: definiuje kryteria akceptacji WP2.
   - Wymagana decyzja: ustalić kody HTTP i format envelope.
+  - Kontekst: odpowiedź jest częścią publicznego kontraktu WP2.
+  - Opcje:
+    - `existing` — zachować istniejący kontrakt. Konsekwencja: mniejszy zakres, ale obecne ograniczenia pozostają.
+    - `redesign` — wprowadzić nowy kontrakt. Konsekwencja: spójniejszy interfejs kosztem zmian klientów i testów.
   - Status: `open`
 
 #### Pytania nieblokujące
@@ -963,8 +1063,8 @@ wymaga jawnej prośby użytkownika.
 Odpowiedź użytkownika wskazuje ID pytania lub pakietu, np.:
 
 ```text
-SQ1: default async
-WP2-Q1: 422 dla błędów domenowych, 403 dla uprawnień, 419 dla CSRF
+SQ1: default
+WP2-Q1: existing
 WP1: revise
 WP2: accept
 ```
@@ -978,6 +1078,40 @@ decision_source
 decided_at
 previous_decision, jeśli dotyczy
 ```
+
+### Propagowanie decyzji do planu
+
+Odpowiedź nie kończy pracy nad pytaniem. Każde rozstrzygnięte pytanie tworzy
+rekord w `user_decisions`:
+
+```yaml
+- decision_ref: D1
+  question_id: WP2-Q1
+  selected_option: existing
+  decision_source: user
+  decided_at: 2026-01-01T00:00:00Z
+  affected_refs:
+    - WP2.scope
+    - WP2.acceptance_criteria
+    - session_strategy
+  propagation_status: propagated
+```
+
+Przed zadaniem następnego pytania agent musi:
+
+1. zachować odpowiedź przy pytaniu;
+2. zaktualizować `scope`, kryteria, zależności, ryzyka, strategię sesji,
+   findings/blockery i `Next action` wskazane przez `affected_refs`;
+3. zaktualizować statusy oraz historię rewizji, jeżeli decyzja zmienia zakres;
+4. ustawić `propagation_status: propagated` dopiero po zapisaniu tych zmian;
+5. atomowo zapisać i zwalidować draft.
+
+`affected_refs` są obowiązkowe. Brak wpływu poza pytaniem zapisuj jawnie jako
+`affected_refs: [question:<id>]`. Decyzja z `propagation_status: pending` albo
+brak rekordu decyzji dla rozstrzygniętego pytania blokuje kolejne pytania,
+otwarcie bramki pakietowej i finalne `approved`. Deterministyczny walidator
+sprawdza kompletność jawnych referencji, ale nie rozstrzyga sam semantycznego
+wpływu decyzji.
 
 Zmiana zakresu pakietu otwiera ponownie jego decyzję, a zmianę pakietów
 zależnych wykonuj tylko wtedy, gdy dowód wskazuje rzeczywisty wpływ na ich
@@ -1100,17 +1234,18 @@ Implementacja: nie uruchomiono.
 
 ### Deterministyczne nazwy draftów
 
-Draft jest artefaktem planu, a nie nowym issue. Nazwa wynika wyłącznie ze
-stabilnej tożsamości źródła i bezpiecznego sluga:
+Draft jest artefaktem planu, a nie nowym issue. Nazwa issue i pakietu
+pochodnego wynika wyłącznie ze stabilnej tożsamości wejścia, aby plik mógł
+powstać przed odczytem treści źródła:
 
 ```text
-github issue:       docs/draft/issue-<id>-<title-slug>-plan.md
-derived package:    docs/draft/issue-<id>-wp-<wpid>-<package-slug>-plan.md
+github issue:       docs/draft/issue-<id>-plan.md
+derived package:    docs/draft/issue-<id>-wp-<wpid>-plan.md
 file source:        docs/draft/task-file-<slug>-plan.md
 user input:         docs/draft/task-<slug>-plan.md
 ```
 
-Slugowanie jest współdzielone przez:
+Slugowanie pozostaje współdzielone dla źródeł file/user-input przez:
 
 ```text
 <skills_root>/_shared/scripts/slugify-title.mjs → slugifyTitle()
@@ -1139,7 +1274,7 @@ Minimalny front matter głównego draftu zawiera:
 source_kind: github-issue
 source_ref: https://github.com/owner/repo/issues/123
 issue: 123
-title: "Original issue title"
+title: "Original issue title" # po source intake; szkic może użyć Pending title
 input_profile: brief-request
 plan_status: review-pending
 package_decision_gate: closed
@@ -1155,6 +1290,7 @@ draft ma sekcje:
 
 ```md
 ## Source
+## Session strategy
 ## Goal and scope
 ## Work packages
 ## Decisions and open questions
@@ -1193,7 +1329,7 @@ Po jawnej decyzji `separate` task-plan tworzy draft pochodny bez tworzenia
 nowego issue. Draft rodzica zawiera link względny do wyniku:
 
 ```md
-WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-import-plan.md)
+WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-plan.md)
 ```
 
 Nowy draft startuje z `plan_status: needs-clarification` i nie jest
@@ -1253,9 +1389,11 @@ kontraktu oraz istniejących helperów. Zakres scenariuszy obejmuje:
 1. trigger, źródła i profile materiału, w tym `title-only`;
 2. granicę `source_data` kontra workflow, dowody i `CONFLICT`;
 3. decyzje work packages, zależności, przejścia statusów i `separated`;
-4. review, limit iteracji, auto-uproszczenie i menu `a/b/c`;
-5. integrację z `$gh-issue-start`, wznowienie draftu i `Execution handoff`;
-6. ownership, redundancję odpowiedzialności, source claims i granice
+4. draft utworzony przed source fetch, strategię sesji, opcje pytań i propagację
+   decyzji;
+5. review, limit iteracji, auto-uproszczenie i menu `a/b/c`;
+6. integrację z `$gh-issue-start`, wznowienie draftu i `Execution handoff`;
+7. ownership, redundancję odpowiedzialności, source claims i granice
    cross-context.
 
 Ponieważ `$task-plan` jest kontraktem Markdown, a nie runtime'em, testy nie
@@ -1273,8 +1411,8 @@ lub środowiska.
 
 | Moduł | Odpowiedzialność | Główne API/komendy |
 |---|---|---|
-| `<skill_dir>/scripts/draft.mjs` | tożsamość, ścieżka, front matter, sekcje, pytania, resume i atomowy zapis | `buildSourceIdentity`, `buildDraftPath`, `buildDraftMetadata`, `validateDraftDocument`, `renderQuestionSections`, `writeAtomicFile`, `writeSeparatedDraft`; `path`, `validate`, `render-questions` |
-| `<skill_dir>/scripts/state.mjs` | jawne przejścia, bramka decyzji pakietowych, walidacja pytań, decyzje, bulk pending, approval guard i graf zależności | `canTransition`, `applyPlanTransition`, `canOpenPackageDecisions`, `validateQuestionRecords`, `applyDecisionCommand`, `applyPackageDecision`, `canApprovePlan`, `getImpactedPackageIds`; `transition`, `parse-command` |
+| `<skill_dir>/scripts/draft.mjs` | tożsamość, stabilna ścieżka, front matter, initial draft, sekcje, pytania, resume i atomowy zapis | `buildSourceIdentity`, `buildDraftPath`, `buildDraftMetadata`, `createInitialDraft`, `renderSessionStrategySection`, `validateDraftDocument`, `renderQuestionSections`, `writeAtomicFile`, `writeSeparatedDraft`; `path`, `validate`, `render-questions` |
+| `<skill_dir>/scripts/state.mjs` | jawne przejścia, bramka decyzji pakietowych, strategia sesji, walidacja pytań/opcji, decyzje i propagacja | `canTransition`, `applyPlanTransition`, `canOpenPackageDecisions`, `validateQuestionRecords`, `validateSessionStrategy`, `applyQuestionDecision`, `validateUserDecisionRecords`, `validateQuestionDecisionPropagation`, `applyDecisionCommand`, `applyPackageDecision`; `transition`, `parse-command` |
 | `<skill_dir>/scripts/source.mjs` | normalizacja GitHub/file/user input oraz bezpieczny odczyt źródeł | `normalizeGitHubIssue`, `normalizeFileSource`, `normalizeUserInput`, `refreshSource`; `normalize-file`, `normalize-user`, `fetch-github` |
 | `<skill_dir>/scripts/validate-plan.mjs` | findings, review limit, simplification invariants, draft/state i final approval | `validateFinding`, `validateReviewHistory`, `validateSimplification`, `validatePlanDocument`, `validateFinalApproval`; `validate`, `validate-state` |
 
@@ -1289,13 +1427,15 @@ Przykładowy przepływ punktowy:
 node <skill_dir>/scripts/source.mjs normalize-file \
   --root "$PWD" --path ./docs/task.md
 node <skill_dir>/scripts/draft.mjs path \
-  --source-kind github-issue --issue 123 --title "Original issue title"
+  --source-kind github-issue --issue 123
+node <skill_dir>/scripts/draft.mjs validate \
+  --file ./docs/draft/issue-123-plan.md
 node <skill_dir>/scripts/state.mjs parse-command \
   --value "accept-selected: WP1, WP2"
 node <skill_dir>/scripts/draft.mjs render-questions \
   --file ./tests/fixtures/task-plan/questions.json
 node <skill_dir>/scripts/validate-plan.mjs validate \
-  --file ./docs/draft/issue-123-original-issue-title-plan.md
+  --file ./docs/draft/issue-123-plan.md
 ```
 
 Operacje wymagające zapisu wywołuj przez eksportowane funkcje z kontrolą
@@ -1321,6 +1461,25 @@ Stan przekazywany do walidatora ma postać danych, nie instrukcji:
   "plan_status": "review-pending",
   "plan_version": 1,
   "packages": [],
+  "session_strategy": {
+    "mode": "staged",
+    "rationale": "WP1 precedes WP2.",
+    "stages": [{
+      "id": "S1",
+      "title": "Contract",
+      "rationale": "Stabilize the shared contract.",
+      "work_package_ids": [],
+      "dependencies": [],
+      "session_boundary": "same-session",
+      "entry_criteria": ["Zakres potwierdzony."],
+      "exit_criteria": ["Etap zakończony."]
+    }],
+    "dependencies": [],
+    "session_boundary_recommendation": "Oddzielna sesja po WP1.",
+    "entry_criteria": ["Zakres potwierdzony."],
+    "exit_criteria": ["Etap zakończony."]
+  },
+  "user_decisions": [],
   "findings": [],
   "review_history": [],
   "decisions": [],

--- a/.agents/skills/task-plan/scripts/draft.mjs
+++ b/.agents/skills/task-plan/scripts/draft.mjs
@@ -10,10 +10,12 @@ import {
     SIMPLIFICATION_STATUSES,
     TERMINAL_PACKAGE_STATUSES,
     validateQuestionRecords,
+    validateSessionStrategy,
 } from "./state.mjs";
 
 export const DRAFT_SECTIONS = Object.freeze([
     "## Source",
+    "## Session strategy",
     "## Goal and scope",
     "## Work packages",
     "## Decisions and open questions",
@@ -22,6 +24,40 @@ export const DRAFT_SECTIONS = Object.freeze([
     "## Next action",
     "## Execution handoff (when implementation is requested)",
 ]);
+
+export const SESSION_STRATEGY_LABELS = Object.freeze([
+    "Mode:",
+    "Rationale:",
+    "Stages:",
+    "Work packages:",
+    "Session boundary recommendation:",
+    "Dependencies:",
+    "Entry criteria:",
+    "Exit criteria:",
+]);
+
+export const DEFAULT_PENDING_TITLE = "Pending title";
+
+export const INITIAL_SESSION_STRATEGY = Object.freeze({
+    mode: "staged",
+    rationale: "Initial draft created before source fetch; strategy is finalized after source intake.",
+    stages: [
+        {
+            id: "S1",
+            title: "Source intake",
+            rationale: "Fetch and assess the source before defining implementation packages.",
+            work_package_ids: [],
+            dependencies: [],
+            session_boundary: "same-session",
+            entry_criteria: ["Intent gate passed."],
+            exit_criteria: ["Source fetched and profile assigned."],
+        },
+    ],
+    session_boundary_recommendation: "Resume in a new session after source intake.",
+    dependencies: ["source fetch"],
+    entry_criteria: ["Source fetched, assessed and profile assigned."],
+    exit_criteria: ["Every blocking question has an explicit user decision."],
+});
 
 export const DETAILED_PLAN_SECTIONS = Object.freeze([
     "## Source plan",
@@ -155,6 +191,7 @@ export function validateDraftDocument(document, options = {}) {
         errors.push(`Missing draft sections: ${missingSections.join(", ")}.`);
     }
     errors.push(...validateQuestionPresentation(parsed.body, parsed.metadata));
+    errors.push(...validateSessionStrategyPresentation(parsed.body));
 
     return {
         valid: errors.length === 0,
@@ -203,20 +240,22 @@ export function buildDraftPath(source, options = {}) {
     const draftRoot = safeRelativePath(options.draftRoot ?? "docs/draft", "draftRoot");
     const maxLength = options.maxSlugLength ?? 80;
     const kind = source?.source_kind;
-    const title = source?.title ?? source?.package_title ?? source?.source_ref ?? "";
-    const slug = slugifyTitle(title, {maxLength}) || "task";
     let filename;
 
     if (kind === "github-issue") {
         const issue = requireIssueId(source.issue_number ?? source.issue);
-        filename = `issue-${issue}-${slug}-plan.md`;
+        filename = `issue-${issue}-plan.md`;
     } else if (kind === "derived-work-package") {
         const issue = requireIssueId(source.issue_number ?? source.issue);
         const packageId = requirePackageId(source.work_package_id).toLowerCase();
-        filename = `issue-${issue}-wp-${packageId}-${slug}-plan.md`;
+        filename = `issue-${issue}-wp-${packageId}-plan.md`;
     } else if (kind === "file") {
+        const title = source?.title ?? source?.package_title ?? source?.source_ref ?? "";
+        const slug = slugifyTitle(title, {maxLength}) || "task";
         filename = `task-file-${slug}-plan.md`;
     } else if (kind === "user-input") {
+        const title = source?.title ?? source?.package_title ?? source?.source_ref ?? "";
+        const slug = slugifyTitle(title, {maxLength}) || "task";
         filename = `task-${slug}-plan.md`;
     } else {
         throw new DraftError("INVALID_DRAFT_PATH", `Unsupported source kind: ${kind ?? ""}.`);
@@ -230,7 +269,7 @@ export function buildDraftMetadata(source, options = {}) {
     const kind = source?.source_kind;
     const metadata = {
         source_kind: kind,
-        source_ref: requireValue(source?.source_ref, "source_ref"),
+        source_ref: requireValue(deriveSourceRef(source, kind), "source_ref"),
         input_profile: source.input_profile ?? "brief-request",
         plan_status: options.planStatus ?? (source.input_profile === "title-only" ? "needs-clarification" : "review-pending"),
         package_decision_gate: options.packageDecisionGate ?? "closed",
@@ -246,7 +285,9 @@ export function buildDraftMetadata(source, options = {}) {
     }
     if (kind === "github-issue") {
         metadata.issue = requireIssueId(source.issue_number ?? source.issue);
-        metadata.title = requireValue(source.title, "title");
+        metadata.title = source.title
+            ? requireValue(source.title, "title")
+            : (options.placeholderTitle ?? DEFAULT_PENDING_TITLE);
     }
     if (kind === "derived-work-package") {
         metadata.parent_draft = requireValue(source.parent_draft, "parent_draft");
@@ -423,6 +464,96 @@ export function writeSeparatedDraft({derivedPath, derivedContent, parentPath, pa
     };
 }
 
+export function renderSessionStrategySection(strategy) {
+    const errors = validateSessionStrategy(strategy);
+    if (errors.length > 0) {
+        throw new DraftError("INVALID_SESSION_STRATEGY", errors.join(" "), {errors});
+    }
+    const stages = strategy.stages.map((stage, index) => {
+        const packages = stage.work_package_ids.length > 0 ? stage.work_package_ids.join(", ") : "none yet";
+        const dependencies = stage.dependencies.length > 0 ? stage.dependencies.map(markdownInline).join(", ") : "none";
+        return `${index + 1}. ${markdownInline(stage.id)} ${markdownInline(stage.title)} — ${markdownInline(stage.rationale)} [${packages}; zależności: ${dependencies}; ${markdownInline(stage.session_boundary)}; wejście: ${stage.entry_criteria.map(markdownInline).join(", ")}; wyjście: ${stage.exit_criteria.map(markdownInline).join(", ")}]`;
+    }).join("; ");
+    return [
+        "## Session strategy",
+        "",
+        `- Mode: \`${markdownInline(strategy.mode)}\``,
+        `- Rationale: ${markdownInline(strategy.rationale)}`,
+        `- Stages: ${stages}`,
+        `- Work packages: ${strategy.stages.flatMap((stage) => stage.work_package_ids).join(", ") || "none yet"}`,
+        `- Session boundary recommendation: ${markdownInline(strategy.session_boundary_recommendation)}`,
+        `- Dependencies: ${strategy.dependencies.length > 0 ? strategy.dependencies.join(", ") : "none"}`,
+        `- Entry criteria: ${strategy.entry_criteria.map(markdownInline).join("; ")}`,
+        `- Exit criteria: ${strategy.exit_criteria.map(markdownInline).join("; ")}`,
+        "",
+    ].join("\n");
+}
+
+export function renderInitialDraftDocument(metadata) {
+    const strategySection = renderSessionStrategySection(INITIAL_SESSION_STRATEGY).trimEnd();
+    const body = [
+        "## Source",
+        "",
+        "- Source fetch pending; provenance is recorded after intake.",
+        "",
+        strategySection,
+        "",
+        "## Goal and scope",
+        "",
+        "- To be established from the fetched source.",
+        "",
+        "## Work packages",
+        "",
+        "- None yet.",
+        "",
+        "## Decisions and open questions",
+        "",
+        "### Decyzje zakresowe przed decyzjami pakietowymi",
+        "",
+        "- Brak.",
+        "",
+        "### Decyzje pakietowe",
+        "",
+        "- Niedostępne: `package_decision_gate` jest zamknięta. Najpierw zakończ review, uproszczenie i decyzje zakresowe.",
+        "",
+        "## Evidence, risks and review",
+        "",
+        "- No evidence is collected before source fetch.",
+        "",
+        "## Acceptance and verification",
+        "",
+        "- To be established from the fetched source.",
+        "",
+        "## Next action",
+        "",
+        "- Fetch and assess the source, then update this draft atomically.",
+        "",
+        "## Execution handoff (when implementation is requested)",
+        "",
+        "- Not applicable for an initial draft.",
+        "",
+    ].join("\n");
+    return `${serializeFrontMatter(metadata)}${body}`;
+}
+
+export function createInitialDraft({source, now, draftRoot = "docs/draft", rootDir, writeFile = writeAtomicFile} = {}) {
+    if (!source || typeof source !== "object") {
+        throw new DraftError("INVALID_SOURCE_IDENTITY", "Initial draft requires a source identity object.");
+    }
+    const metadata = buildDraftMetadata(source, {now});
+    const relativePath = buildDraftPath(source, {draftRoot});
+    const target = rootDir ? path.resolve(rootDir, relativePath) : path.resolve(relativePath);
+    const content = renderInitialDraftDocument(metadata);
+    writeFile(target, content, rootDir ? {rootDir} : {});
+    return {
+        path: relativePath,
+        target,
+        content,
+        metadata,
+        written: true,
+    };
+}
+
 function validateRequiredMetadata(metadata) {
     const errors = [];
     const required = [
@@ -506,15 +637,28 @@ function validateKindMetadata(metadata, kind) {
     return [];
 }
 
-function validateQuestionPresentation(body, metadata = {}) {
-    const heading = "## Decisions and open questions";
-    const start = body.indexOf(heading);
-    if (start < 0) {
+function validateSessionStrategyPresentation(body) {
+    const headingMatch = /^##\s+Session strategy\s*$/m.exec(body);
+    if (!headingMatch) {
         return [];
     }
-    const sectionStart = start + heading.length;
+    const sectionStart = headingMatch.index + headingMatch[0].length;
     const remainder = body.slice(sectionStart);
-    const nextSection = remainder.search(/\n##\s/);
+    const nextSection = remainder.search(/^##\s/m);
+    const section = nextSection >= 0 ? remainder.slice(0, nextSection) : remainder;
+    return SESSION_STRATEGY_LABELS
+        .filter((label) => !section.includes(label))
+        .map((label) => `Session strategy section is missing ${label}`);
+}
+
+function validateQuestionPresentation(body, metadata = {}) {
+    const headingMatch = /^##\s+Decisions and open questions\s*$/m.exec(body);
+    if (!headingMatch) {
+        return [];
+    }
+    const sectionStart = headingMatch.index + headingMatch[0].length;
+    const remainder = body.slice(sectionStart);
+    const nextSection = remainder.search(/^##\s/m);
     const section = nextSection >= 0 ? remainder.slice(0, nextSection) : remainder;
     const errors = [];
     if (!section.includes("### Decyzje zakresowe przed decyzjami pakietowymi")) {
@@ -698,6 +842,21 @@ function parseGitHubSourceRef(value) {
     return {owner: match[1], repo: match[2]};
 }
 
+function deriveSourceRef(source, kind) {
+    if (source?.source_ref) {
+        return source.source_ref;
+    }
+    if (kind === "github-issue") {
+        const owner = source?.owner;
+        const repo = source?.repo;
+        if (typeof owner === "string" && owner.trim() !== "" && typeof repo === "string" && repo.trim() !== "") {
+            const issue = requireIssueId(source.issue_number ?? source.issue);
+            return `https://github.com/${owner}/${repo}/issues/${issue}`;
+        }
+    }
+    return null;
+}
+
 function toSourceIdentityInput(metadata) {
     return {
         source_kind: metadata.source_kind,
@@ -775,13 +934,32 @@ function renderQuestionList(questions) {
     return questions.flatMap((question) => {
         const marker = question.blocking ? "BLOCKING" : "NON-BLOCKING";
         const status = question.resolved ? "resolved" : "open";
-        return [
+        const lines = [
             `- **${question.id} [${marker}]** ${markdownInline(question.prompt)}`,
             `  - Wpływ: ${markdownInline(question.impact)}`,
             `  - Wymagana decyzja: ${markdownInline(question.decision_needed)}`,
             `  - Status: \`${status}\``,
-            ...(question.resolved ? [`  - Odpowiedź: ${markdownInline(question.answer)}`] : []),
         ];
+        if (question.context) {
+            lines.push(`  - Kontekst: ${markdownInline(question.context)}`);
+        }
+        if (Array.isArray(question.options) && question.options.length > 0) {
+            lines.push("  - Opcje:");
+            for (const option of question.options) {
+                const optionTitle = markdownInline(option.label ?? option.description ?? option.id);
+                lines.push(`    - \`${markdownInline(option.id)}\` — ${optionTitle}`);
+                lines.push(`      - Konsekwencja/tradeoff: ${markdownInline(option.consequence)}`);
+            }
+        }
+        if (question.resolved) {
+            const selected = Array.isArray(question.options)
+                ? question.options.find((option) => option.id === question.answer)
+                : null;
+            lines.push(selected
+                ? `  - Odpowiedź: \`${markdownInline(selected.id)}\` — ${markdownInline(selected.label ?? selected.description ?? selected.id)}`
+                : `  - Odpowiedź: ${markdownInline(question.answer)}`);
+        }
+        return lines;
     });
 }
 

--- a/.agents/skills/task-plan/scripts/state.mjs
+++ b/.agents/skills/task-plan/scripts/state.mjs
@@ -70,6 +70,18 @@ export const OWNERSHIP_REDUNDANCY_STATUSES = Object.freeze([
 
 export const REDUNDANT_DESIGN_ELEMENT = "REDUNDANT_DESIGN_ELEMENT";
 
+export const SESSION_STRATEGY_MODES = Object.freeze([
+    "single-session",
+    "staged",
+    "hybrid",
+]);
+
+export const USER_DECISION_PROPAGATION_STATUSES = Object.freeze([
+    "pending",
+    "propagated",
+]);
+
+const QUESTION_ID = /^(SQ[1-9][0-9]*|WP[1-9][0-9]*-Q[1-9][0-9]*)$/;
 const OWNERSHIP_SUBJECT_ID = /^OR[1-9][0-9]*$/;
 const OWNERSHIP_FINDING_ID = /^F[1-9][0-9]*$/;
 
@@ -508,6 +520,15 @@ function packageDecisionGateReasons(state) {
     for (const reason of ownershipRedundancyReasons(candidate)) {
         addReason(reason);
     }
+    for (const reason of unpropagatedUserDecisionReasons(candidate)) {
+        addReason(reason);
+    }
+    if (validateQuestionDecisionPropagation(candidate).length > 0) {
+        addReason("question_decision_propagation_incomplete");
+    }
+    if (validateSessionStrategy(candidate.session_strategy).length > 0) {
+        addReason("invalid_session_strategy");
+    }
     for (const reason of blockerReasons(candidate)) {
         addReason(reason);
     }
@@ -551,6 +572,19 @@ function ownershipRedundancyReasons(candidate) {
     }
 
     return reasons;
+}
+
+function unpropagatedUserDecisionReasons(candidate) {
+    if (!Object.hasOwn(candidate, "user_decisions")) {
+        return [];
+    }
+    if (!Array.isArray(candidate.user_decisions)) {
+        return ["invalid_user_decisions"];
+    }
+    const pending = candidate.user_decisions.filter((record) => {
+        return record && record.propagation_status !== "propagated";
+    });
+    return pending.length > 0 ? ["unpropagated_user_decisions"] : [];
 }
 
 function hasCompletedCriticalReview(history) {
@@ -660,9 +694,281 @@ export function validateQuestionRecords(questions, options = {}) {
         } else if (QUESTION_RESOLUTION_FIELDS.some((field) => hasMeaningfulQuestionValue(question[field]))) {
             errors.push(`${label} cannot contain an answer before resolved is true.`);
         }
+        if (question.context !== null && typeof question.context !== "undefined") {
+            if (typeof question.context !== "string" || question.context.trim() === "") {
+                errors.push(`${label} context must be a non-empty string.`);
+            }
+        }
+        errors.push(...validateQuestionOptions(question, index));
+        if (question.resolved === true
+            && Array.isArray(question.options)
+            && question.options.length > 0
+            && !question.options.some((option) => option && option.id === question.answer)) {
+            errors.push(`${label} answer must select one of the declared options.`);
+        }
     }
 
     return errors;
+}
+
+function validateQuestionOptions(question, index) {
+    const label = `Question ${index + 1}`;
+    if (typeof question.options === "undefined") {
+        return [];
+    }
+    if (!Array.isArray(question.options)) {
+        return [`${label} options must be an array.`];
+    }
+
+    const errors = [];
+    const optionIds = new Set();
+    for (const [optionIndex, option] of question.options.entries()) {
+        const optionLabel = `${label} option ${optionIndex + 1}`;
+        if (!option || typeof option !== "object" || Array.isArray(option)) {
+            errors.push(`${optionLabel} must be an object.`);
+            continue;
+        }
+        if (typeof option.id !== "string" || option.id.trim() === "") {
+            errors.push(`${optionLabel} must contain a non-empty id.`);
+        } else if (optionIds.has(option.id)) {
+            errors.push(`${optionLabel} has duplicate id ${option.id}.`);
+        } else {
+            optionIds.add(option.id);
+        }
+        const hasLabel = typeof option.label === "string" && option.label.trim() !== "";
+        const hasDescription = typeof option.description === "string" && option.description.trim() !== "";
+        if (!hasLabel && !hasDescription) {
+            errors.push(`${optionLabel} must contain label or description.`);
+        }
+        if (typeof option.consequence !== "string" || option.consequence.trim() === "") {
+            errors.push(`${optionLabel} must contain a consequence/tradeoff.`);
+        }
+    }
+    return errors;
+}
+
+export function validateSessionStrategy(strategy) {
+    if (typeof strategy === "undefined" || strategy === null) {
+        return ["Plan state must contain session_strategy."];
+    }
+    if (!isRecord(strategy)) {
+        return ["session_strategy must be an object."];
+    }
+
+    const errors = [];
+    if (!SESSION_STRATEGY_MODES.includes(strategy.mode)) {
+        errors.push("session_strategy.mode is invalid.");
+    }
+    if (!isNonEmptyString(strategy.rationale)) {
+        errors.push("session_strategy.rationale must be a non-empty string.");
+    }
+    if (!Array.isArray(strategy.stages) || strategy.stages.length === 0) {
+        errors.push("session_strategy.stages must be a non-empty array.");
+    } else {
+        const stageIds = new Set();
+        for (const [index, stage] of strategy.stages.entries()) {
+            const label = `session_strategy.stages[${index}]`;
+            if (!isRecord(stage)) {
+                errors.push(`${label} must be an object.`);
+                continue;
+            }
+            errors.push(...validateSessionStageFields(stage, label));
+            if (!/^S[1-9][0-9]*$/.test(stage.id ?? "")) {
+                errors.push(`${label}.id must match S<number>.`);
+            } else if (stageIds.has(stage.id)) {
+                errors.push(`${label}.id is duplicated: ${stage.id}.`);
+            } else {
+                stageIds.add(stage.id);
+            }
+            errors.push(...validateSessionStagePackages(stage, label));
+            errors.push(...validateSessionStageCriteria(stage, label));
+        }
+    }
+    if (!isNonEmptyString(strategy.session_boundary_recommendation)) {
+        errors.push("session_strategy.session_boundary_recommendation must be a non-empty string.");
+    }
+    if (!Array.isArray(strategy.dependencies)) {
+        errors.push("session_strategy.dependencies must be an array.");
+    } else {
+        for (const [index, dependency] of strategy.dependencies.entries()) {
+            if (!isNonEmptyString(dependency)) {
+                errors.push(`session_strategy.dependencies[${index}] must be a non-empty string.`);
+            }
+        }
+    }
+    for (const field of ["entry_criteria", "exit_criteria"]) {
+        if (!Array.isArray(strategy[field]) || strategy[field].length === 0) {
+            errors.push(`session_strategy.${field} must be a non-empty array.`);
+        } else {
+            for (const [index, criterion] of strategy[field].entries()) {
+                if (!isNonEmptyString(criterion)) {
+                    errors.push(`session_strategy.${field}[${index}] must be a non-empty string.`);
+                }
+            }
+        }
+    }
+    return errors;
+}
+
+export function validateUserDecisionRecords(records) {
+    if (!Array.isArray(records)) {
+        return ["user_decisions must be an array."];
+    }
+
+    const errors = [];
+    const refs = new Set();
+    for (const [index, record] of records.entries()) {
+        const label = `user_decision ${index + 1}`;
+        if (!isRecord(record)) {
+            errors.push(`${label} must be an object.`);
+            continue;
+        }
+        if (!isNonEmptyString(record.decision_ref)) {
+            errors.push(`${label} is missing decision_ref.`);
+        } else if (refs.has(record.decision_ref)) {
+            errors.push(`Duplicate decision_ref: ${record.decision_ref}.`);
+        } else {
+            refs.add(record.decision_ref);
+        }
+        if (!isNonEmptyString(record.question_id) || !QUESTION_ID.test(record.question_id)) {
+            errors.push(`${label} question_id must match SQ<number> or WP<number>-Q<number>.`);
+        }
+        const hasSelectedOption = hasMeaningfulQuestionValue(record.selected_option);
+        const hasAnswer = hasMeaningfulQuestionValue(record.answer);
+        if (hasSelectedOption === hasAnswer) {
+            errors.push(`${label} must contain exactly one of selected_option or answer.`);
+        }
+        if (!isNonEmptyString(record.decision_source)) {
+            errors.push(`${label} is missing decision_source.`);
+        }
+        if (typeof record.decided_at !== "string" || Number.isNaN(Date.parse(record.decided_at))) {
+            errors.push(`${label} decided_at must be a valid timestamp.`);
+        }
+        if (!Array.isArray(record.affected_refs)) {
+            errors.push(`${label} affected_refs must be an array.`);
+        } else {
+            if (record.affected_refs.length === 0) {
+                errors.push(`${label} affected_refs must not be empty.`);
+            }
+            for (const [refIndex, ref] of record.affected_refs.entries()) {
+                if (!isNonEmptyString(ref)) {
+                    errors.push(`${label} affected_refs[${refIndex}] must be a non-empty string.`);
+                }
+            }
+        }
+        if (!USER_DECISION_PROPAGATION_STATUSES.includes(record.propagation_status)) {
+            errors.push(`${label} propagation_status is invalid.`);
+        }
+    }
+    return errors;
+}
+
+export function validateQuestionDecisionPropagation(state) {
+    const errors = [];
+    if (!state || typeof state !== "object") {
+        return errors;
+    }
+    const records = Array.isArray(state.user_decisions) ? state.user_decisions : [];
+    const questions = [];
+    appendQuestionRecords(questions, state.scope_questions);
+    if (Array.isArray(state.packages)) {
+        for (const item of state.packages) {
+            if (!item || !Array.isArray(item.questions)) {
+                continue;
+            }
+            appendQuestionRecords(questions, item.questions);
+        }
+    }
+
+    const questionIds = new Set(questions.map((question) => question.id));
+    for (const question of questions) {
+        if (question.resolved !== true) {
+            continue;
+        }
+        const record = records.find((candidate) => candidate && candidate.question_id === question.id);
+        if (!record) {
+            errors.push(`Resolved question ${question.id} is missing a user_decisions record.`);
+            continue;
+        }
+        if (Array.isArray(question.options) && question.options.length > 0) {
+            if (!isNonEmptyString(record.selected_option)) {
+                errors.push(`User decision for ${question.id} must record selected_option.`);
+            } else if (!question.options.some((option) => option && option.id === record.selected_option)) {
+                errors.push(`User decision for ${question.id} selected_option must be one of the declared options.`);
+            } else if (record.selected_option !== question.answer) {
+                errors.push(`User decision for ${question.id} answer must match the selected option.`);
+            }
+        } else if (!isNonEmptyString(record.answer)) {
+            errors.push(`User decision for ${question.id} must record answer.`);
+        } else if (record.answer !== question.answer) {
+            errors.push(`User decision for ${question.id} answer must match the resolved question answer.`);
+        }
+    }
+
+    for (const record of records) {
+        if (record && !questionIds.has(record.question_id)) {
+            errors.push(`user_decisions references unknown question ${record.question_id ?? "unknown"}.`);
+        }
+        if (record && record.propagation_status !== "propagated") {
+            errors.push(`user_decisions propagation incomplete for ${record.decision_ref ?? "unknown"}.`);
+        }
+    }
+    return errors;
+}
+
+export function applyQuestionDecision(state, decision) {
+    const nextState = prepareState(state);
+    const questionId = requireString(decision?.question_id, "question_id");
+    const question = findQuestion(nextState, questionId);
+    if (!question) {
+        throw new StateError("QUESTION_NOT_FOUND", `Question ${questionId} was not found.`, {question_id: questionId});
+    }
+    if (question.resolved === true) {
+        throw new StateError("QUESTION_ALREADY_RESOLVED", `Question ${questionId} is already resolved.`, {question_id: questionId});
+    }
+
+    const selectedOption = decision?.selected_option;
+    const answer = decision?.answer;
+    const hasSelectedOption = hasMeaningfulQuestionValue(selectedOption);
+    const hasAnswer = hasMeaningfulQuestionValue(answer);
+    if (hasSelectedOption === hasAnswer) {
+        throw new StateError("INVALID_QUESTION_DECISION", "A question decision must contain exactly one of selected_option or answer.");
+    }
+    if (hasSelectedOption && (!Array.isArray(question.options)
+        || !question.options.some((option) => option?.id === selectedOption))) {
+        throw new StateError("INVALID_QUESTION_DECISION", `Selected option is not declared for ${questionId}.`, {
+            question_id: questionId,
+        });
+    }
+    if (Array.isArray(question.options) && question.options.length > 0 && !hasSelectedOption) {
+        throw new StateError("INVALID_QUESTION_DECISION", `${questionId} requires selected_option because it declares options.`, {
+            question_id: questionId,
+        });
+    }
+
+    const record = {
+        decision_ref: requireString(decision?.decision_ref, "decision_ref"),
+        question_id: questionId,
+        ...(hasSelectedOption ? {selected_option: selectedOption} : {answer}),
+        decision_source: requireString(decision?.decision_source, "decision_source"),
+        decided_at: requireTimestamp(decision?.decided_at, "decided_at"),
+        affected_refs: Array.isArray(decision?.affected_refs) ? [...decision.affected_refs] : [],
+        propagation_status: "pending",
+    };
+    if (nextState.user_decisions.some((candidate) => candidate.decision_ref === record.decision_ref)) {
+        throw new StateError("DUPLICATE_DECISION_REF", `Decision ref ${record.decision_ref} is already recorded.`);
+    }
+    const recordErrors = validateUserDecisionRecords([record]);
+    if (recordErrors.length > 0) {
+        throw new StateError("INVALID_QUESTION_DECISION", recordErrors.join(" "), {errors: recordErrors});
+    }
+
+    question.resolved = true;
+    question.answer = hasSelectedOption ? selectedOption : answer;
+    question.decision_source = record.decision_source;
+    question.decided_at = record.decided_at;
+    nextState.user_decisions.push(record);
+    return nextState;
 }
 
 export function validateOwnershipRedundancyReview(review, findings) {
@@ -1103,11 +1409,85 @@ function prepareState(state) {
     if (decisionResult.length > 0) {
         throw new StateError("INVALID_STATE", decisionResult.join(" "), {errors: decisionResult});
     }
+    const strategyErrors = validateSessionStrategy(state.session_strategy);
+    if (strategyErrors.length > 0) {
+        throw new StateError("INVALID_STATE", strategyErrors.join(" "), {errors: strategyErrors});
+    }
+    if (Object.hasOwn(state, "user_decisions")) {
+        const userDecisionErrors = validateUserDecisionRecords(state.user_decisions);
+        if (userDecisionErrors.length > 0) {
+            throw new StateError("INVALID_STATE", userDecisionErrors.join(" "), {errors: userDecisionErrors});
+        }
+    }
 
     return {
         ...clone(state),
         decisions: Array.isArray(state.decisions) ? clone(state.decisions) : [],
+        user_decisions: Array.isArray(state.user_decisions) ? clone(state.user_decisions) : [],
     };
+}
+
+function findQuestion(state, questionId) {
+    const scopeQuestion = (state.scope_questions ?? []).find((question) => question?.id === questionId);
+    if (scopeQuestion) {
+        return scopeQuestion;
+    }
+    for (const packageRecord of state.packages ?? []) {
+        const packageQuestion = (packageRecord.questions ?? []).find((question) => question?.id === questionId);
+        if (packageQuestion) {
+            return packageQuestion;
+        }
+    }
+    return null;
+}
+
+function validateSessionStageFields(stage, label) {
+    const errors = [];
+    for (const field of ["id", "title", "rationale", "session_boundary"]) {
+        if (!isNonEmptyString(stage[field])) {
+            errors.push(`${label}.${field} must be a non-empty string.`);
+        }
+    }
+    if (!Array.isArray(stage.dependencies)) {
+        errors.push(`${label}.dependencies must be an array.`);
+    } else if (stage.dependencies.some((dependency) => !isNonEmptyString(dependency))) {
+        errors.push(`${label}.dependencies must contain non-empty strings.`);
+    }
+    return errors;
+}
+
+function validateSessionStagePackages(stage, label) {
+    if (!Array.isArray(stage.work_package_ids)) {
+        return [`${label}.work_package_ids must be an array.`];
+    }
+    return stage.work_package_ids.flatMap((packageId, index) => {
+        return /^WP[1-9][0-9]*$/.test(packageId ?? "")
+            ? []
+            : [`${label}.work_package_ids[${index}] must match WP<number>.`];
+    });
+}
+
+function validateSessionStageCriteria(stage, label) {
+    const errors = [];
+    for (const field of ["entry_criteria", "exit_criteria"]) {
+        if (!Array.isArray(stage[field]) || stage[field].length === 0) {
+            errors.push(`${label}.${field} must be a non-empty array.`);
+        } else if (stage[field].some((criterion) => !isNonEmptyString(criterion))) {
+            errors.push(`${label}.${field} must contain non-empty strings.`);
+        }
+    }
+    return errors;
+}
+
+function appendQuestionRecords(target, candidates) {
+    if (!Array.isArray(candidates)) {
+        return;
+    }
+    for (const question of candidates) {
+        if (question && typeof question === "object" && !Array.isArray(question)) {
+            target.push(question);
+        }
+    }
 }
 
 function transitionTable(kind) {

--- a/.agents/skills/task-plan/scripts/validate-plan.mjs
+++ b/.agents/skills/task-plan/scripts/validate-plan.mjs
@@ -14,6 +14,9 @@ import {
     canOpenPackageDecisions,
     validateDecisionHistory,
     validatePackageRecords,
+    validateQuestionDecisionPropagation,
+    validateSessionStrategy,
+    validateUserDecisionRecords,
     PLAN_STATUSES,
     readSimplificationResult,
     REDUNDANT_DESIGN_ELEMENT,
@@ -375,6 +378,13 @@ function validateStateRecords(state) {
     }, {
         requireOwnershipReview: true,
     }));
+    errors.push(...validateSessionStrategy(state.session_strategy).map((error) => {
+        return `session_strategy: ${error}`;
+    }));
+    errors.push(...validateUserDecisionRecords(state.user_decisions ?? []).map((error) => {
+        return `user_decisions: ${error}`;
+    }));
+    errors.push(...validateQuestionDecisionPropagation(state));
     return errors;
 }
 

--- a/tests/fixtures/task-plan/draft-derived.md
+++ b/tests/fixtures/task-plan/draft-derived.md
@@ -3,7 +3,7 @@ source_kind: derived-work-package
 source_ref: https://github.com/acme/demo/issues/123
 input_profile: brief-request
 parent_issue: 123
-parent_draft: issue-123-main-title-plan.md
+parent_draft: issue-123-plan.md
 work_package_id: WP2
 plan_status: needs-clarification
 package_decision_gate: closed
@@ -16,7 +16,18 @@ source_updated_at: 2026-01-01T00:00:00Z
 ## Source
 
 - source_kind: derived-work-package
-- parent_draft: issue-123-main-title-plan.md
+- parent_draft: issue-123-plan.md
+
+## Session strategy
+
+- Mode: `decisions`
+- Rationale: The separated package runs its own bounded workflow.
+- Stages: 1. intake; 2. planning; 3. review; 4. decisions
+- Work packages: WP2
+- Session boundary recommendation: resume in a dedicated session.
+- Dependencies: parent draft separation link
+- Entry criteria: explicit `separate` decision recorded.
+- Exit criteria: every blocking question has an explicit user decision.
 
 ## Goal and scope
 

--- a/tests/fixtures/task-plan/draft-main.md
+++ b/tests/fixtures/task-plan/draft-main.md
@@ -17,6 +17,17 @@ source_updated_at: 2026-01-01T00:00:00Z
 - source_data: issue body and comments
 - source_ref: https://github.com/acme/demo/issues/123
 
+## Session strategy
+
+- Mode: `planning`
+- Rationale: Plan the accepted goal from the fetched issue before package decisions.
+- Stages: 1. intake; 2. planning; 3. review; 4. decisions
+- Work packages: WP1, WP2
+- Session boundary recommendation: resume after the review gate opens.
+- Dependencies: source fetch, repository context
+- Entry criteria: source fetched and assessed.
+- Exit criteria: every blocking question has an explicit user decision.
+
 ## Goal and scope
 
 Implement the explicitly accepted goal without expanding the source scope.
@@ -26,7 +37,7 @@ Implement the explicitly accepted goal without expanding the source scope.
 - WP1 — core package, status `pending`.
 - WP2 — package pending review and a later decision.
 - No package decision is requested before the review gate opens.
-- After an explicit `separate`: WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-import-plan.md)
+- After an explicit `separate`: WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-plan.md)
 
 ## Decisions and open questions
 

--- a/tests/fixtures/task-plan/draft-operations.json
+++ b/tests/fixtures/task-plan/draft-operations.json
@@ -3,7 +3,7 @@
     "source_identity": "acme/demo/123",
     "issue": "123",
     "title": "Zażółć gęślą jaźń!",
-    "expected_path": "docs/draft/issue-123-zazolc-gesla-jazn-plan.md",
+    "expected_path": "docs/draft/issue-123-plan.md",
     "plan_version_before": 1,
     "plan_version_after_resume": 2
   },
@@ -17,8 +17,8 @@
     "issue": "123",
     "work_package_id": "WP2",
     "package_title": "Import",
-    "expected_path": "docs/draft/issue-123-wp-wp2-import-plan.md",
-    "parent_link": "WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-import-plan.md)",
+    "expected_path": "docs/draft/issue-123-wp-wp2-plan.md",
+    "parent_link": "WP2 — wydzielony do [osobnego planu](./issue-123-wp-wp2-plan.md)",
     "plan_status": "needs-clarification",
     "on_write_failure": {
       "parent_preserved": true,

--- a/tests/fixtures/task-plan/draft-questions.md
+++ b/tests/fixtures/task-plan/draft-questions.md
@@ -17,8 +17,14 @@
 
 - **WP1-Q1 [BLOCKING]** Jakie kody HTTP obowiązują dla błędów domenowych, uprawnień i CSRF?
   - Wpływ: Definiuje kryteria akceptacji kontraktu odpowiedzi.
-  - Wymagana decyzja: Wskazać kody HTTP.
+  - Wymagana decyzja: Wybrać wariant kontraktu i wskazać kody HTTP.
   - Status: `open`
+  - Kontekst: Decyzja ustala kontrakt odpowiedzi i wpływa na kryteria akceptacji WP1.
+  - Opcje:
+    - `existing` — Zachować istniejące konwencje
+      - Konsekwencja/tradeoff: Ogranicza zakres i ryzyko kompatybilności, ale utrwala obecny kontrakt.
+    - `redesign` — Wprowadzić nowy kontrakt
+      - Konsekwencja/tradeoff: Daje spójniejszy interfejs, ale rozszerza zakres i może wymagać zmian klientów.
 
 #### Pytania nieblokujące
 

--- a/tests/fixtures/task-plan/questions.json
+++ b/tests/fixtures/task-plan/questions.json
@@ -32,10 +32,25 @@
         {
           "id": "WP1-Q1",
           "prompt": "Jakie kody HTTP obowiązują dla błędów domenowych, uprawnień i CSRF?",
+          "context": "Decyzja ustala kontrakt odpowiedzi i wpływa na kryteria akceptacji WP1.",
           "blocking": true,
           "resolved": false,
           "impact": "Definiuje kryteria akceptacji kontraktu odpowiedzi.",
-          "decision_needed": "Wskazać kody HTTP."
+          "decision_needed": "Wybrać wariant kontraktu i wskazać kody HTTP.",
+          "options": [
+            {
+              "id": "existing",
+              "label": "Zachować istniejące konwencje",
+              "description": "Użyć obecnych kodów i envelope.",
+              "consequence": "Ogranicza zakres i ryzyko kompatybilności, ale utrwala obecny kontrakt."
+            },
+            {
+              "id": "redesign",
+              "label": "Wprowadzić nowy kontrakt",
+              "description": "Ujednolicić kody i envelope.",
+              "consequence": "Daje spójniejszy interfejs, ale rozszerza zakres i może wymagać zmian klientów."
+            }
+          ]
         }
       ]
     },

--- a/tests/fixtures/task-plan/workflow-scenarios.json
+++ b/tests/fixtures/task-plan/workflow-scenarios.json
@@ -123,7 +123,10 @@
       "required_anchors": [
         "gh-issue-status-set",
         "`start.mjs` nie pobiera body ani komentarzy.",
-        "issue-<id>-<title-slug>-plan.md",
+        "issue-<id>-plan.md",
+        "Po przejściu bramki intencji task-plan najpierw tworzy",
+        "przed każdą serią pytań",
+        "## Session strategy",
         "## Execution handoff",
         "Plan version",
         "docs/SKILLS.md",

--- a/tests/skills/task-plan/task-plan-contract.test.mjs
+++ b/tests/skills/task-plan/task-plan-contract.test.mjs
@@ -3,7 +3,6 @@ import path from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 
-import {slugifyTitle} from "../../../.agents/skills/_shared/scripts/slugify-title.mjs";
 import {buildDraftMetadata} from "../../../.agents/skills/task-plan/scripts/draft.mjs";
 import {
     applyPlanTransition,
@@ -44,6 +43,7 @@ const PLAN_STATUSES = new Set([
 
 const DRAFT_SECTIONS = [
     "## Source",
+    "## Session strategy",
     "## Goal and scope",
     "## Work packages",
     "## Decisions and open questions",
@@ -181,6 +181,24 @@ describe("task-plan workflow scenarios", () => {
             blockers: [],
             findings: [],
             scope_questions: [],
+            session_strategy: {
+                mode: "staged",
+                rationale: "WP1 is the core stage.",
+                stages: [{
+                    id: "S1",
+                    title: "Core",
+                    rationale: "Stabilize the core contract.",
+                    work_package_ids: ["WP1"],
+                    dependencies: [],
+                    session_boundary: "same-session",
+                    entry_criteria: ["Scope confirmed."],
+                    exit_criteria: ["Contract documented."],
+                }],
+                session_boundary_recommendation: "Review later work separately.",
+                dependencies: [],
+                entry_criteria: ["Intent confirmed."],
+                exit_criteria: ["Stage complete."],
+            },
             ownership_redundancy_review: {
                 required: false,
                 requirement_basis: "not-applicable",
@@ -249,7 +267,7 @@ describe("task-plan status transitions", () => {
 
 describe("task-plan draft operations", () => {
     it("builds the stable main draft path from the issue number and title", () => {
-        const pathName = `docs/draft/issue-${DRAFT_OPERATIONS.main.issue}-${slugifyTitle(DRAFT_OPERATIONS.main.title)}-plan.md`;
+        const pathName = `docs/draft/issue-${DRAFT_OPERATIONS.main.issue}-plan.md`;
 
         expect(pathName).toBe(DRAFT_OPERATIONS.main.expected_path);
     });
@@ -274,7 +292,7 @@ describe("task-plan draft operations", () => {
     });
 
     it("builds the stable derived draft path and keeps the separate-work-package contract", () => {
-        const pathName = `docs/draft/issue-${DRAFT_OPERATIONS.derived.issue}-wp-${DRAFT_OPERATIONS.derived.work_package_id.toLowerCase()}-${slugifyTitle(DRAFT_OPERATIONS.derived.package_title)}-plan.md`;
+        const pathName = `docs/draft/issue-${DRAFT_OPERATIONS.derived.issue}-wp-${DRAFT_OPERATIONS.derived.work_package_id.toLowerCase()}-plan.md`;
         const metadata = parseFrontMatter(DERIVED_DRAFT);
 
         expect(pathName).toBe(DRAFT_OPERATIONS.derived.expected_path);
@@ -283,7 +301,7 @@ describe("task-plan draft operations", () => {
             source_ref: "https://github.com/acme/demo/issues/123",
             input_profile: "brief-request",
             parent_issue: "123",
-            parent_draft: "issue-123-main-title-plan.md",
+            parent_draft: "issue-123-plan.md",
             work_package_id: "WP2",
             plan_status: DRAFT_OPERATIONS.derived.plan_status,
         });

--- a/tests/skills/task-plan/task-plan-questions.test.mjs
+++ b/tests/skills/task-plan/task-plan-questions.test.mjs
@@ -36,6 +36,8 @@ describe("task-plan question contract", () => {
         });
         expect(cliResult.status).toBe(0);
         expect(JSON.parse(cliResult.stdout).markdown).toBe(EXPECTED_MARKDOWN);
+        expect(EXPECTED_MARKDOWN).toContain("Konsekwencja/tradeoff: Ogranicza zakres");
+        expect(EXPECTED_MARKDOWN).toContain("Kontekst: Decyzja ustala kontrakt");
     });
 
     it("requires stable IDs and structured question fields", () => {
@@ -65,6 +67,15 @@ describe("task-plan question contract", () => {
             "Question 1 is missing decision_source for a resolved question.",
             "Question 1 is missing decided_at for a resolved question.",
         ]));
+        expect(validateQuestionRecords([{
+            id: "WP1-Q1",
+            prompt: "Który wariant?",
+            blocking: true,
+            resolved: false,
+            impact: "Zakres",
+            decision_needed: "Wybrać wariant.",
+            options: [{id: "a", label: "A"}],
+        }], {packageId: "WP1"})).toContain("Question 1 option 1 must contain a consequence/tradeoff.");
     });
 
     it("keeps complete and incomplete ownership review states separate from package questions", () => {
@@ -195,6 +206,24 @@ describe("task-plan question contract", () => {
             simplification_status: "pending",
             blockers: [],
             scope_questions: [],
+            session_strategy: {
+                mode: "staged",
+                rationale: "Initial review is separate from package decisions.",
+                stages: [{
+                    id: "S1",
+                    title: "Review",
+                    rationale: "Complete review before package decisions.",
+                    work_package_ids: [],
+                    dependencies: [],
+                    session_boundary: "same-session",
+                    entry_criteria: ["Draft exists."],
+                    exit_criteria: ["Review complete."],
+                }],
+                session_boundary_recommendation: "Continue after review.",
+                dependencies: [],
+                entry_criteria: ["Intent confirmed."],
+                exit_criteria: ["Questions are explicit."],
+            },
             ownership_redundancy_review: {
                 required: false,
                 requirement_basis: "not-applicable",

--- a/tests/skills/task-plan/task-plan-scripts.test.mjs
+++ b/tests/skills/task-plan/task-plan-scripts.test.mjs
@@ -9,8 +9,10 @@ import {
     DraftError,
     buildDraftPath,
     buildSourceIdentity,
+    createInitialDraft,
     parseDraftDocument,
     prepareResumeMetadata,
+    renderSessionStrategySection,
     validateDraftDocument,
     writeAtomicFile,
     writeSeparatedDraft,
@@ -28,6 +30,10 @@ import {
     reopenPackage,
     validateDependencyGraph,
     validateOwnershipRedundancyReview,
+    validateSessionStrategy,
+    validateUserDecisionRecords,
+    validateQuestionDecisionPropagation,
+    applyQuestionDecision,
 } from "../../../.agents/skills/task-plan/scripts/state.mjs";
 import {
     compareSourceSnapshots,
@@ -77,15 +83,89 @@ describe("task-plan draft module", () => {
             source_kind: "github-issue",
             issue: "123",
             title: "Zażółć gęślą jaźń!",
-        })).toBe("docs/draft/issue-123-zazolc-gesla-jazn-plan.md");
+        })).toBe("docs/draft/issue-123-plan.md");
         expect(buildDraftPath({
             source_kind: "user-input",
             title: "!!!",
         })).toBe("docs/draft/task-task-plan.md");
+        expect(buildDraftPath({
+            source_kind: "file",
+            source_ref: "docs/task.md",
+        })).toBe("docs/draft/task-file-docstaskmd-plan.md");
+        expect(buildDraftPath({
+            source_kind: "github-issue",
+            issue: "123",
+            title: "A different fetched title",
+        })).toBe(buildDraftPath({
+            source_kind: "github-issue",
+            issue: "123",
+            title: "Original title",
+        }));
         expect(() => buildDraftPath({
             source_kind: "user-input",
             title: "x",
         }, {draftRoot: "../outside"})).toThrow(DraftError);
+    });
+
+    it("creates a valid initial draft before source details are fetched", () => {
+        const directory = makeTemporaryDirectory();
+        let sourceRead = false;
+        const result = createInitialDraft({
+            source: {
+                source_kind: "github-issue",
+                owner: "acme",
+                repo: "demo",
+                issue_number: "123",
+            },
+            now: "2026-01-01T00:00:00Z",
+            rootDir: directory,
+            writeFile: (target, content, options) => {
+                expect(sourceRead).toBe(false);
+                fs.mkdirSync(path.dirname(target), {recursive: true});
+                fs.writeFileSync(target, content, "utf8");
+                return {path: target, written: true, options};
+            },
+        });
+        sourceRead = true;
+
+        expect(result.path).toBe("docs/draft/issue-123-plan.md");
+        expect(fs.existsSync(path.join(directory, result.path))).toBe(true);
+        expect(validateDraftDocument(result.content, {kind: "main"}).valid).toBe(true);
+        expect(parseDraftDocument(result.content).metadata.title).toBe("Pending title");
+    });
+
+    it("keeps the initial draft after source failure and resumes the same path", () => {
+        const directory = makeTemporaryDirectory();
+        const initial = createInitialDraft({
+            source: {source_kind: "github-issue", owner: "acme", repo: "demo", issue_number: "123"},
+            now: "2026-01-01T00:00:00Z",
+            rootDir: directory,
+        });
+
+        expect(() => fetchGitHubIssue({
+            owner: "acme",
+            repo: "demo",
+            issueNumber: "123",
+            resolveCommand: () => "gh",
+            execCommand: () => ({status: 1, stderr: "network unavailable"}),
+        })).toThrow(SourceError);
+
+        const draftPath = path.join(directory, initial.path);
+        const savedDraft = fs.readFileSync(draftPath, "utf8");
+        expect(validateDraftDocument(savedDraft, {kind: "main"}).valid).toBe(true);
+        const resumed = prepareResumeMetadata(
+            parseDraftDocument(savedDraft).metadata,
+            {
+                source_kind: "github-issue",
+                source_ref: "https://github.com/acme/demo/issues/123",
+                issue_number: "123",
+                title: "Fetched title",
+                source_updated_at: "2026-01-02T00:00:00Z",
+            },
+            {now: "2026-01-02T00:00:00Z"},
+        );
+        expect(resumed.plan_version).toBe("2");
+        expect(buildDraftPath(resumed)).toBe(initial.path);
     });
 
     it("validates fixture documents and parses scalar front matter", () => {
@@ -192,6 +272,34 @@ describe("task-plan draft module", () => {
             work_package_id: "WP2",
         })).toBe("acme/demo/123/wp/WP2");
     });
+
+    it("validates staged session strategy with explicit package grouping", () => {
+        const strategy = {
+            mode: "staged",
+            rationale: "Separate review from implementation.",
+            stages: [{
+                id: "S1",
+                title: "Core contract",
+                rationale: "Stabilize the shared contract first.",
+                work_package_ids: ["WP1"],
+                dependencies: [],
+                session_boundary: "separate-session",
+                entry_criteria: ["Source assessed."],
+                exit_criteria: ["WP1 contract accepted."],
+            }],
+            session_boundary_recommendation: "Start WP2 in a new session.",
+            dependencies: ["WP1 before WP2"],
+            entry_criteria: ["Intent confirmed."],
+            exit_criteria: ["All stages have terminal decisions."],
+        };
+        expect(validateSessionStrategy(strategy)).toEqual([]);
+        expect(renderSessionStrategySection(strategy)).toContain("Stabilize the shared contract first.");
+        expect(renderSessionStrategySection(strategy)).toContain("zależności: none");
+        expect(validateSessionStrategy({...strategy, mode: "unsupported"})).toContain("session_strategy.mode is invalid.");
+        expect(validateSessionStrategy({...strategy, stages: [{...strategy.stages[0], entry_criteria: []}]})).toContain(
+            "session_strategy.stages[0].entry_criteria must be a non-empty array.",
+        );
+    });
 });
 
 describe("task-plan state module", () => {
@@ -239,6 +347,9 @@ describe("task-plan state module", () => {
             plan_status: "review-pending",
         };
         expect(canOpenPackageDecisions(ready)).toEqual({ready: true, reasons: []});
+        const withoutStrategy = {...ready};
+        delete withoutStrategy.session_strategy;
+        expect(canOpenPackageDecisions(withoutStrategy).reasons).toContain("invalid_session_strategy");
         expect(canTransition("plan", "review-pending", "awaiting-package-decisions", ready)).toBe(true);
         expect(applyPlanTransition(ready, "awaiting-package-decisions", {
             reason: "critical review and simplification complete",
@@ -367,6 +478,78 @@ describe("task-plan state module", () => {
             decision_source: "user",
             decided_at: "2026-01-02T00:00:00Z",
         }), "INVALID_BULK_DECISION");
+    });
+
+    it("records and validates propagation of a user answer", () => {
+        const state = {
+            ...baseState(),
+            packages: [{
+                ...baseState().packages[0],
+                questions: [{
+                    id: "WP1-Q1",
+                    prompt: "Który kontrakt obowiązuje?",
+                    context: "Decyzja zmienia kryteria WP1.",
+                    blocking: true,
+                    resolved: false,
+                    impact: "Wpływa na API.",
+                    decision_needed: "Wybrać kontrakt.",
+                    options: [
+                        {id: "existing", label: "Istniejący", consequence: "Mniejszy zakres i ryzyko migracji."},
+                        {id: "new", label: "Nowy", consequence: "Większy zakres, ale spójniejszy kontrakt."},
+                    ],
+                }],
+            }],
+        };
+        const pending = applyQuestionDecision(state, {
+            question_id: "WP1-Q1",
+            decision_ref: "D1",
+            selected_option: "existing",
+            decision_source: "user",
+            decided_at: "2026-01-02T00:00:00Z",
+            affected_refs: ["WP1.scope", "WP1.acceptance_criteria"],
+            propagation_status: "propagated",
+        });
+
+        expect(pending.user_decisions[0].propagation_status).toBe("pending");
+        expect(validateQuestionDecisionPropagation(pending)).toContain("user_decisions propagation incomplete for D1.");
+        expect(canOpenPackageDecisions(pending).reasons).toContain("question_decision_propagation_incomplete");
+        const propagated = structuredClone(pending);
+        propagated.user_decisions[0].propagation_status = "propagated";
+        expect(validateUserDecisionRecords(propagated.user_decisions)).toEqual([]);
+        expect(validateQuestionDecisionPropagation(propagated)).toEqual([]);
+        expect(canApprovePlan(pending).reasons).toContain("question_decision_propagation_incomplete");
+
+        const missingRecord = structuredClone(propagated);
+        missingRecord.user_decisions = [];
+        expect(validateQuestionDecisionPropagation(missingRecord)).toContain(
+            "Resolved question WP1-Q1 is missing a user_decisions record.",
+        );
+        const mismatched = structuredClone(propagated);
+        mismatched.user_decisions[0].selected_option = "new";
+        expect(validateQuestionDecisionPropagation(mismatched)).toContain(
+            "User decision for WP1-Q1 answer must match the selected option.",
+        );
+        const unknown = structuredClone(propagated);
+        unknown.user_decisions.push({
+            decision_ref: "D9",
+            question_id: "WP9-Q1",
+            answer: "unused",
+            decision_source: "user",
+            decided_at: "2026-01-02T00:00:00Z",
+            affected_refs: ["question:WP9-Q1"],
+            propagation_status: "propagated",
+        });
+        expect(validateQuestionDecisionPropagation(unknown)).toContain(
+            "user_decisions references unknown question WP9-Q1.",
+        );
+        expectErrorCode(() => applyQuestionDecision(state, {
+            question_id: "WP1-Q1",
+            decision_ref: "D2",
+            answer: "free text",
+            decision_source: "user",
+            decided_at: "2026-01-02T00:00:00Z",
+            affected_refs: ["WP1.scope"],
+        }), "INVALID_QUESTION_DECISION");
     });
 
     it("reopens terminal packages explicitly and computes dependent impact", () => {
@@ -784,6 +967,7 @@ describe("task-plan validation module", () => {
             review_history: [],
             decisions: [],
             simplification: {result: "pending"},
+            session_strategy: sessionStrategy(),
             ownership_redundancy_review: notRequiredOwnershipReview(),
         }).valid).toBe(true);
         const invalid = validatePlanState({...baseState(), plan_status: "approved", blockers: ["B1"]});
@@ -857,6 +1041,19 @@ describe("task-plan CLI contract", () => {
         expect(invalidStateResult.status).toBe(1);
         expect(JSON.parse(invalidStateResult.stdout).errors).toContain("Plan state must contain ownership_redundancy_review.");
     });
+
+    it("resolves a title-independent GitHub draft path without fetching the source", () => {
+        const result = runCli(DRAFT_SCRIPT, [
+            "path",
+            "--source-kind",
+            "github-issue",
+            "--issue",
+            "123",
+        ]);
+
+        expect(result.status).toBe(0);
+        expect(JSON.parse(result.stdout).path).toBe("docs/draft/issue-123-plan.md");
+    });
 });
 
 function baseState() {
@@ -895,6 +1092,7 @@ function baseState() {
         review_complete: true,
         scope_questions: [],
         decisions: [],
+        session_strategy: sessionStrategy(),
         ownership_redundancy_review: notRequiredOwnershipReview(),
     };
 }
@@ -941,6 +1139,27 @@ function notRequiredOwnershipReview() {
         requirement_decision_ref: "",
         status: "not-required",
         subjects: [],
+    };
+}
+
+function sessionStrategy() {
+    return {
+        mode: "staged",
+        rationale: "WP1 precedes dependent work.",
+        stages: [{
+            id: "S1",
+            title: "Core",
+            rationale: "Stabilize the core contract first.",
+            work_package_ids: ["WP1"],
+            dependencies: [],
+            session_boundary: "same-session",
+            entry_criteria: ["Scope confirmed."],
+            exit_criteria: ["Core contract documented."],
+        }],
+        session_boundary_recommendation: "Review dependent work in a new session.",
+        dependencies: ["WP2 depends_on WP1"],
+        entry_criteria: ["Intent confirmed."],
+        exit_criteria: ["Every stage has a terminal result."],
     };
 }
 


### PR DESCRIPTION
## Zmiany ogólne
- Utworzono stabilne drafty Markdown przed pobraniem źródeł oraz dodano strategię sesji z etapami work packages.
- Rozszerzono pytania o kontekst, opcje i konsekwencje oraz dodano walidowaną propagację decyzji użytkownika do planu i bramek workflow.
- Uzupełniono fixture’y i testy regresyjne dla lifecycle draftu, strategii sesji, decyzji i ścieżek CLI.

## Zmiany API poleceń CLI
- Ustabilizowano ścieżki draftów GitHub i pakietów pochodnych niezależnie od tytułu źródła.